### PR TITLE
fix(web): iOS Safari viewport/inset 2차 보정

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'dart:ui';
 import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:a_and_i_report_web_server/src/core/routes/route_config.dart';
 import 'package:a_and_i_report_web_server/src/core/theme/app_theme.dart';
@@ -40,6 +41,20 @@ class MyApp extends ConsumerWidget {
       routerConfig: goRouter,
       theme: theme,
       scrollBehavior: const AppScrollBehavior(),
+      builder: (context, child) {
+        if (child == null || !_shouldOverrideWebIosInsets()) {
+          return child ?? const SizedBox.shrink();
+        }
+
+        final mediaQuery = MediaQuery.of(context);
+        return MediaQuery(
+          data: mediaQuery.copyWith(
+            padding: EdgeInsets.zero,
+            viewPadding: EdgeInsets.zero,
+          ),
+          child: child,
+        );
+      },
     );
   }
 }
@@ -53,4 +68,8 @@ class AppScrollBehavior extends MaterialScrollBehavior {
         PointerDeviceKind.mouse,
         PointerDeviceKind.trackpad,
       };
+}
+
+bool _shouldOverrideWebIosInsets() {
+  return kIsWeb && defaultTargetPlatform == TargetPlatform.iOS;
 }

--- a/web/index.html
+++ b/web/index.html
@@ -50,9 +50,9 @@
       body {
         overflow-x: hidden;
         overflow-y: auto;
-        min-height: 100dvh;
+        min-height: 100lvh;
         min-height: -webkit-fill-available;
-        min-height: var(--app-viewport-height, 100dvh);
+        min-height: var(--app-viewport-height, 100lvh);
       }
 
       /* Safari 툴바 축소 트리거를 위해 문서 루트에 최소 스크롤 여유를 둔다. */
@@ -65,17 +65,37 @@
       flt-glass-pane,
       flt-scene-host,
       flutter-view {
-        height: var(--app-viewport-height, 100dvh) !important;
+        min-height: var(--app-viewport-height, 100lvh) !important;
+        height: var(--app-viewport-height, 100lvh) !important;
       }
     </style>
     <script>
       (function () {
         const root = document.documentElement;
+        const isIOS = (() => {
+          const ua = window.navigator.userAgent;
+          return (
+            /iPad|iPhone|iPod/.test(ua) ||
+            (window.navigator.platform === "MacIntel" &&
+              window.navigator.maxTouchPoints > 1)
+          );
+        })();
+
+        const resolveViewportHeight = () => {
+          const viewport = window.visualViewport;
+          const visualHeight = viewport
+            ? viewport.height + viewport.offsetTop
+            : 0;
+          const innerHeight = window.innerHeight || 0;
+          const clientHeight = document.documentElement.clientHeight || 0;
+          return Math.max(visualHeight, innerHeight, clientHeight);
+        };
 
         const syncViewportHeight = () => {
-          const viewport = window.visualViewport;
-          const viewportHeight = viewport ? viewport.height : window.innerHeight;
-          root.style.setProperty("--app-viewport-height", `${viewportHeight}px`);
+          root.style.setProperty(
+            "--app-viewport-height",
+            `${resolveViewportHeight()}px`
+          );
         };
 
         window.addEventListener("resize", syncViewportHeight, { passive: true });
@@ -89,6 +109,21 @@
           });
           window.visualViewport.addEventListener("scroll", syncViewportHeight, {
             passive: true,
+          });
+        }
+
+        if (isIOS) {
+          const nudgeBrowserBars = () => {
+            if (window.scrollY < 1) {
+              window.scrollTo(0, 1);
+            }
+          };
+
+          window.addEventListener("touchstart", nudgeBrowserBars, {
+            passive: true,
+          });
+          window.addEventListener("load", () => {
+            window.setTimeout(nudgeBrowserBars, 250);
           });
         }
 


### PR DESCRIPTION
PR 본문

## 배경
  iOS Safari(리퀴드 글라스)에서 Flutter Web 페이지 스크롤 시,
  - 상/하단 브라우저 영역까지 콘텐츠가 확장되지 않고
  - SafeArea가 과도하게 적용된 것처럼 보이는 문제가 있었습니다.

  1차 대응 후에도 일부 기기/상태에서 동일 증상이 남아 2차 보정을 진행했습니다.

## 변경 사항

### 1) iOS Web 전역 inset 오버라이드
  - 파일: `lib/main.dart`
  - `MaterialApp.router.builder`에서 iOS Web(`kIsWeb && TargetPlatform.iOS`)일 때:
    - `MediaQuery.padding = EdgeInsets.zero`
    - `MediaQuery.viewPadding = EdgeInsets.zero`
  - 목적:
    - Flutter Web이 전달하는 iOS safe inset이 레이아웃에 과도 반영되는 현상 완화

### 2) viewport 높이 계산 로직 강화
  - 파일: `web/index.html`
  - `--app-viewport-height` 계산을 단일 `visualViewport.height` 의존에서 변경:
    - `max(visualViewport.height + offsetTop, window.innerHeight, documentElement.clientHeight)`
  - `100dvh` 기반을 `100lvh` + 동적 CSS 변수 기반으로 보정
  - Flutter 루트 요소(`flt-glass-pane`, `flt-scene-host`, `flutter-view`) 높이 동기화 유지

### 3) iOS Safari 주소창 동작 유도
  - 파일: `web/index.html`
  - iOS에서 초기/터치 시작 시 `window.scrollTo(0,1)` nudge 적용
  - 목적:
    - Safari 브라우저 바 축소 트리거 보조

## 기대 효과
  - iOS Safari에서 상/하단 브라우저 영역까지 레이아웃 확장 개선
  - SafeArea처럼 보이던 과도 여백 완화
  - 기기 회전/브라우저 UI 변화 시 viewport 높이 동기화 안정성 향상

## 영향 범위
  - Web 런타임 레이어(`web/index.html`) + 앱 루트 MediaQuery 처리(`lib/main.dart`)
  - 도메인/유스케이스/리포지토리 비즈니스 로직 변경 없음