### PR TITLE
fix: retry 401 requests after token refresh

### DIFF
--- a/lib/src/core/interceptors/auth_interceptor.dart
+++ b/lib/src/core/interceptors/auth_interceptor.dart
@@ -23,15 +23,25 @@ class AuthInterceptor extends QueuedInterceptor {
     ErrorInterceptorHandler handler,
   ) async {
     final requestOptions = err.requestOptions;
-    final hasAuthHeader = _readAuthorizationHeader(requestOptions) != null;
     final isUnauthorized = err.response?.statusCode == 401;
     final isRefreshApi = _isRefreshApi(requestOptions);
     final alreadyRetried = requestOptions.extra[_retryKey] == true;
 
-    // Authorization 헤더가 포함된 요청 + 401 에러에서만 토큰 갱신 시도
-    if (isUnauthorized && hasAuthHeader && !isRefreshApi && !alreadyRetried) {
+    // 401 에러 발생 시 토큰 갱신을 시도한다.
+    // 헤더가 누락되었더라도 로컬 토큰이 있으면 재발급을 시도해
+    // 브라우저/프록시 환경에서의 헤더 유실 케이스를 흡수한다.
+    if (isUnauthorized && !isRefreshApi && !alreadyRetried) {
       String? refreshToken;
       try {
+        final authorizationHeader = _readAuthorizationHeader(requestOptions);
+        final accessToken = await localAuthDatasource.getUserToken();
+        final hasAuthContext =
+            _hasToken(authorizationHeader) || _hasToken(accessToken);
+
+        if (!hasAuthContext) {
+          return handler.next(err);
+        }
+
         log('401 에러 발생, 토큰 갱신 시도...');
 
         // 리프레시 토큰 조회
@@ -43,53 +53,40 @@ class AuthInterceptor extends QueuedInterceptor {
         }
 
         // 토큰 갱신 API 호출
-        final response = await dio.post(
-          _refreshPath,
-          data: {'refreshToken': refreshToken},
-          options: Options(
-            headers: {'Content-Type': 'application/json'},
-          ),
-        );
+        final response = await _requestTokenRefresh(refreshToken);
 
         // 응답 데이터 안전하게 파싱
-        if (response.statusCode == 200 && response.data is Map) {
-          final responseData = response.data as Map;
-          final data = responseData['data'];
-          if (responseData['success'] == true && data is Map) {
-            final newAccessToken = data['accessToken']?.toString();
-            final newRefreshToken = data['refreshToken']?.toString();
-
-            if (newAccessToken == null || newAccessToken.isEmpty) {
-              log('토큰 갱신 응답에 accessToken이 없음');
-              await onTokenExpired(refreshToken);
-              return handler.reject(err);
-            }
-
-            // 새 토큰 저장 (refreshToken은 내려준 경우에만 갱신)
-            await localAuthDatasource.saveUserToken(newAccessToken);
-            if (newRefreshToken != null && newRefreshToken.isNotEmpty) {
-              await localAuthDatasource.saveRefreshToken(newRefreshToken);
-            }
-
-            log('토큰 갱신 성공');
-
-            // 원래 요청 재시도 (무한 재시도 방지 플래그 포함)
-            _setAuthorizationHeader(requestOptions, 'Bearer $newAccessToken');
-            final retryOptions = _buildRetryOptions(requestOptions)
-              ..extra[_retryKey] = true;
-
-            final retryResponse = await dio.fetch<dynamic>(retryOptions);
-            return handler.resolve(retryResponse);
-          } else {
-            log('토큰 갱신 응답 포맷이 유효하지 않음');
-            await onTokenExpired(refreshToken);
-            return handler.reject(err);
-          }
-        } else {
+        final statusCode = response.statusCode ?? 0;
+        if (statusCode < 200 || statusCode >= 300) {
           log('토큰 갱신 실패, 로그아웃 처리');
           await onTokenExpired(refreshToken);
           return handler.reject(err);
         }
+
+        final newAccessToken = _extractAccessToken(response.data);
+        final newRefreshToken = _extractRefreshToken(response.data);
+
+        if (!_hasToken(newAccessToken)) {
+          log('토큰 갱신 응답에 accessToken이 없음');
+          await onTokenExpired(refreshToken);
+          return handler.reject(err);
+        }
+
+        // 새 토큰 저장 (refreshToken은 내려준 경우에만 갱신)
+        await localAuthDatasource.saveUserToken(newAccessToken!);
+        if (_hasToken(newRefreshToken)) {
+          await localAuthDatasource.saveRefreshToken(newRefreshToken!);
+        }
+
+        log('토큰 갱신 성공');
+
+        // 원래 요청 재시도 (무한 재시도 방지 플래그 포함)
+        final retryOptions = _buildRetryOptions(requestOptions)
+          ..extra[_retryKey] = true;
+        _setAuthorizationHeader(retryOptions, 'Bearer $newAccessToken');
+
+        final retryResponse = await dio.fetch<dynamic>(retryOptions);
+        return handler.resolve(retryResponse);
       } on DioException catch (e) {
         log('토큰 갱신 중 에러 발생: ${e.response?.statusCode}');
         // 리프레시 토큰도 만료된 경우 (401)
@@ -107,10 +104,59 @@ class AuthInterceptor extends QueuedInterceptor {
     return handler.next(err);
   }
 
+  Future<Response<dynamic>> _requestTokenRefresh(String refreshToken) {
+    final refreshDio = Dio(dio.options.copyWith());
+
+    return refreshDio.post<dynamic>(
+      _refreshPath,
+      data: {'refreshToken': refreshToken},
+      options: Options(
+        headers: {'Content-Type': 'application/json'},
+      ),
+    );
+  }
+
   bool _isRefreshApi(RequestOptions options) {
     final parsed = Uri.tryParse(options.path);
     final normalizedPath = parsed?.path ?? options.path;
     return normalizedPath.endsWith(_refreshPath);
+  }
+
+  bool _hasToken(String? token) {
+    if (token == null) {
+      return false;
+    }
+    return token.trim().isNotEmpty;
+  }
+
+  String? _extractAccessToken(dynamic body) {
+    final root = _toMap(body);
+    if (root == null) {
+      return null;
+    }
+    final data = _toMap(root['data']);
+    final token = data?['accessToken'] ?? root['accessToken'];
+    return token?.toString();
+  }
+
+  String? _extractRefreshToken(dynamic body) {
+    final root = _toMap(body);
+    if (root == null) {
+      return null;
+    }
+    final data = _toMap(root['data']);
+    final token = data?['refreshToken'] ?? root['refreshToken'];
+    return token?.toString();
+  }
+
+  Map<String, dynamic>? _toMap(dynamic source) {
+    if (source is Map<String, dynamic>) {
+      return source;
+    }
+    if (source is Map) {
+      return Map<String, dynamic>.from(source);
+    }
+    return null;
   }
 
   String? _readAuthorizationHeader(RequestOptions options) {


### PR DESCRIPTION
## 변경 내용 (What)

  - 401 응답 시 JWT 재발급/재요청 로직을 AuthInterceptor에서 안정화했습니다.
  - Authorization 헤더가 누락돼도 로컬 access token 이 있으면 재발급을 시도하도록 조건을 보강했습니다.
  - refresh 요청을 기존 인터셉터 체인과 분리된 별도 Dio 인스턴스로 호출하도록 변경했습니다.
  - refresh 응답 파싱을 유연화했습니다. (data.accessToken 우선, 루트 accessToken fallback)
  - 재시도 요청 시 새 access token 을 헤더에 주입하고 1회만 재시도하도록 유지했습니다.

  ## 확인 방법 (How to check)

  - 만료된 access token + 유효한 refresh token 상태로 인증 API 호출
  - 최초 요청이 401이어도 /v1/auth/refresh 호출 후 원래 요청이 자동 재시도되어 정상 응답되는지 확인
  - refresh token 도 만료된 경우 세션 정리(로그아웃) 처리되는지 확인
  - 정적 분석: flutter analyze 실행 (기존 경고만 존재, 신규 에러 없음)

  ## 체크리스트

  - [x] PR 목적이 하나입니다 (한 PR = 한 목적)
  - [x] 변경 범위를 최소화했습니다
  - [ ] 문서/가이드가 필요하면 함께 업데이트했습니다
  - [x] (선택) 스크린샷/로그/요청·응답 예시를 첨부했습니다