### PR TITLE
feat(reports): update current week badge logic

### DIFF
--- a/lib/src/feature/home/data/dtos/report_summary_response_dto.dart
+++ b/lib/src/feature/home/data/dtos/report_summary_response_dto.dart
@@ -272,6 +272,7 @@ class CourseOutlineAssignmentDto {
   /// 화면용 요약 엔티티로 변환합니다.
   ReportSummary? toSummary(ReportType reportType) {
     final level = _parseLevel(difficulty);
+    final resolvedStartAt = startAt;
     final resolvedEndAt = endAt;
 
     if (assignmentId.isEmpty ||
@@ -289,6 +290,7 @@ class CourseOutlineAssignmentDto {
       title: title,
       level: level,
       reportType: reportType,
+      startAt: resolvedStartAt,
       endAt: resolvedEndAt,
     );
   }
@@ -383,6 +385,7 @@ ReportSummary? _toSummary(Map<String, dynamic> json) {
         attributesMap?['reportType'] ??
         json['reportType'],
   );
+  final startAt = _parseDateTime(json['startAt']);
   final endAt = _parseDateTime(json['endAt']);
 
   if (id == null ||
@@ -402,6 +405,7 @@ ReportSummary? _toSummary(Map<String, dynamic> json) {
     title: title,
     level: level,
     reportType: reportType,
+    startAt: startAt,
     endAt: endAt,
   );
 }

--- a/lib/src/feature/home/data/entities/report_summary.dart
+++ b/lib/src/feature/home/data/entities/report_summary.dart
@@ -27,6 +27,9 @@ sealed class ReportSummary with _$ReportSummary {
     /// 과제 유형 (CS, Algorithm 등)
     required ReportType reportType,
 
+    /// 과제 시작일
+    DateTime? startAt,
+
     /// 제출 마감일
     required DateTime endAt,
   }) = _ReportSummary;

--- a/lib/src/feature/home/data/entities/report_summary.freezed.dart
+++ b/lib/src/feature/home/data/entities/report_summary.freezed.dart
@@ -32,6 +32,9 @@ mixin _$ReportSummary {
   /// 과제 유형 (CS, Algorithm 등)
   ReportType get reportType;
 
+  /// 과제 시작일
+  DateTime? get startAt;
+
   /// 제출 마감일
   DateTime get endAt;
 
@@ -58,17 +61,18 @@ mixin _$ReportSummary {
             (identical(other.level, level) || other.level == level) &&
             (identical(other.reportType, reportType) ||
                 other.reportType == reportType) &&
+            (identical(other.startAt, startAt) || other.startAt == startAt) &&
             (identical(other.endAt, endAt) || other.endAt == endAt));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, id, week, seq, title, level, reportType, endAt);
+  int get hashCode => Object.hash(
+      runtimeType, id, week, seq, title, level, reportType, startAt, endAt);
 
   @override
   String toString() {
-    return 'ReportSummary(id: $id, week: $week, seq: $seq, title: $title, level: $level, reportType: $reportType, endAt: $endAt)';
+    return 'ReportSummary(id: $id, week: $week, seq: $seq, title: $title, level: $level, reportType: $reportType, startAt: $startAt, endAt: $endAt)';
   }
 }
 
@@ -85,6 +89,7 @@ abstract mixin class $ReportSummaryCopyWith<$Res> {
       String title,
       Level level,
       ReportType reportType,
+      DateTime? startAt,
       DateTime endAt});
 }
 
@@ -107,6 +112,7 @@ class _$ReportSummaryCopyWithImpl<$Res>
     Object? title = null,
     Object? level = null,
     Object? reportType = null,
+    Object? startAt = freezed,
     Object? endAt = null,
   }) {
     return _then(_self.copyWith(
@@ -134,6 +140,10 @@ class _$ReportSummaryCopyWithImpl<$Res>
           ? _self.reportType
           : reportType // ignore: cast_nullable_to_non_nullable
               as ReportType,
+      startAt: freezed == startAt
+          ? _self.startAt
+          : startAt // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
       endAt: null == endAt
           ? _self.endAt
           : endAt // ignore: cast_nullable_to_non_nullable
@@ -234,7 +244,7 @@ extension ReportSummaryPatterns on ReportSummary {
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>(
     TResult Function(String id, int week, int seq, String title, Level level,
-            ReportType reportType, DateTime endAt)?
+            ReportType reportType, DateTime? startAt, DateTime endAt)?
         $default, {
     required TResult orElse(),
   }) {
@@ -242,7 +252,7 @@ extension ReportSummaryPatterns on ReportSummary {
     switch (_that) {
       case _ReportSummary() when $default != null:
         return $default(_that.id, _that.week, _that.seq, _that.title,
-            _that.level, _that.reportType, _that.endAt);
+            _that.level, _that.reportType, _that.startAt, _that.endAt);
       case _:
         return orElse();
     }
@@ -264,14 +274,14 @@ extension ReportSummaryPatterns on ReportSummary {
   @optionalTypeArgs
   TResult when<TResult extends Object?>(
     TResult Function(String id, int week, int seq, String title, Level level,
-            ReportType reportType, DateTime endAt)
+            ReportType reportType, DateTime? startAt, DateTime endAt)
         $default,
   ) {
     final _that = this;
     switch (_that) {
       case _ReportSummary():
         return $default(_that.id, _that.week, _that.seq, _that.title,
-            _that.level, _that.reportType, _that.endAt);
+            _that.level, _that.reportType, _that.startAt, _that.endAt);
     }
   }
 
@@ -290,14 +300,14 @@ extension ReportSummaryPatterns on ReportSummary {
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>(
     TResult? Function(String id, int week, int seq, String title, Level level,
-            ReportType reportType, DateTime endAt)?
+            ReportType reportType, DateTime? startAt, DateTime endAt)?
         $default,
   ) {
     final _that = this;
     switch (_that) {
       case _ReportSummary() when $default != null:
         return $default(_that.id, _that.week, _that.seq, _that.title,
-            _that.level, _that.reportType, _that.endAt);
+            _that.level, _that.reportType, _that.startAt, _that.endAt);
       case _:
         return null;
     }
@@ -314,6 +324,7 @@ class _ReportSummary implements ReportSummary {
       required this.title,
       required this.level,
       required this.reportType,
+      this.startAt,
       required this.endAt});
   factory _ReportSummary.fromJson(Map<String, dynamic> json) =>
       _$ReportSummaryFromJson(json);
@@ -341,6 +352,10 @@ class _ReportSummary implements ReportSummary {
   /// 과제 유형 (CS, Algorithm 등)
   @override
   final ReportType reportType;
+
+  /// 과제 시작일
+  @override
+  final DateTime? startAt;
 
   /// 제출 마감일
   @override
@@ -373,17 +388,18 @@ class _ReportSummary implements ReportSummary {
             (identical(other.level, level) || other.level == level) &&
             (identical(other.reportType, reportType) ||
                 other.reportType == reportType) &&
+            (identical(other.startAt, startAt) || other.startAt == startAt) &&
             (identical(other.endAt, endAt) || other.endAt == endAt));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, id, week, seq, title, level, reportType, endAt);
+  int get hashCode => Object.hash(
+      runtimeType, id, week, seq, title, level, reportType, startAt, endAt);
 
   @override
   String toString() {
-    return 'ReportSummary(id: $id, week: $week, seq: $seq, title: $title, level: $level, reportType: $reportType, endAt: $endAt)';
+    return 'ReportSummary(id: $id, week: $week, seq: $seq, title: $title, level: $level, reportType: $reportType, startAt: $startAt, endAt: $endAt)';
   }
 }
 
@@ -402,6 +418,7 @@ abstract mixin class _$ReportSummaryCopyWith<$Res>
       String title,
       Level level,
       ReportType reportType,
+      DateTime? startAt,
       DateTime endAt});
 }
 
@@ -424,6 +441,7 @@ class __$ReportSummaryCopyWithImpl<$Res>
     Object? title = null,
     Object? level = null,
     Object? reportType = null,
+    Object? startAt = freezed,
     Object? endAt = null,
   }) {
     return _then(_ReportSummary(
@@ -451,6 +469,10 @@ class __$ReportSummaryCopyWithImpl<$Res>
           ? _self.reportType
           : reportType // ignore: cast_nullable_to_non_nullable
               as ReportType,
+      startAt: freezed == startAt
+          ? _self.startAt
+          : startAt // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
       endAt: null == endAt
           ? _self.endAt
           : endAt // ignore: cast_nullable_to_non_nullable

--- a/lib/src/feature/home/data/entities/report_summary.g.dart
+++ b/lib/src/feature/home/data/entities/report_summary.g.dart
@@ -14,6 +14,9 @@ _ReportSummary _$ReportSummaryFromJson(Map<String, dynamic> json) =>
       title: json['title'] as String,
       level: $enumDecode(_$LevelEnumMap, json['level']),
       reportType: $enumDecode(_$ReportTypeEnumMap, json['reportType']),
+      startAt: json['startAt'] == null
+          ? null
+          : DateTime.parse(json['startAt'] as String),
       endAt: DateTime.parse(json['endAt'] as String),
     );
 
@@ -25,6 +28,7 @@ Map<String, dynamic> _$ReportSummaryToJson(_ReportSummary instance) =>
       'title': instance.title,
       'level': _$LevelEnumMap[instance.level]!,
       'reportType': _$ReportTypeEnumMap[instance.reportType]!,
+      'startAt': instance.startAt?.toIso8601String(),
       'endAt': instance.endAt.toIso8601String(),
     };
 

--- a/lib/src/feature/reports/ui/utils/report_progress.dart
+++ b/lib/src/feature/reports/ui/utils/report_progress.dart
@@ -1,0 +1,33 @@
+import 'package:a_and_i_report_web_server/src/feature/home/data/entities/report_summary.dart';
+
+/// 과제가 시작되었는지 여부를 반환합니다.
+bool hasReportStarted(ReportSummary report, {DateTime? now}) {
+  final startAt = report.startAt;
+  if (startAt == null) {
+    return false;
+  }
+
+  final currentTime = (now ?? DateTime.now()).toUtc();
+  return !startAt.isAfter(currentTime);
+}
+
+/// 시작한 과제 중 가장 최신 주차를 반환합니다.
+///
+/// `startAt`이 현재 시각보다 이전이거나 같은 과제만 시작한 것으로 간주하며,
+/// 그중 가장 큰 주차 번호를 현재 진행 중인 주차로 사용합니다.
+int? findCurrentProgressWeek(List<ReportSummary> reports, {DateTime? now}) {
+  final currentTime = (now ?? DateTime.now()).toUtc();
+  int? latestWeek;
+
+  for (final report in reports) {
+    if (!hasReportStarted(report, now: currentTime)) {
+      continue;
+    }
+
+    if (latestWeek == null || report.week > latestWeek) {
+      latestWeek = report.week;
+    }
+  }
+
+  return latestWeek;
+}

--- a/lib/src/feature/reports/ui/view/report_list_view.dart
+++ b/lib/src/feature/reports/ui/view/report_list_view.dart
@@ -8,6 +8,7 @@ import 'package:a_and_i_report_web_server/src/feature/auth/ui/viewModels/user_vi
 import 'package:a_and_i_report_web_server/src/feature/home/data/entities/level.dart';
 import 'package:a_and_i_report_web_server/src/feature/home/data/entities/report_summary.dart';
 import 'package:a_and_i_report_web_server/src/feature/home/data/entities/report_type.dart';
+import 'package:a_and_i_report_web_server/src/feature/reports/ui/utils/report_progress.dart';
 import 'package:a_and_i_report_web_server/src/feature/reports/ui/viewModel/report_list_view_model.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
@@ -180,6 +181,7 @@ class _ReportListViewState extends ConsumerState<ReportListView> {
   }
 
   List<_CourseSection> _buildSections(List<ReportSummary> reports) {
+    final currentTime = DateTime.now().toUtc();
     final sorted = List<ReportSummary>.of(reports)
       ..sort((a, b) {
         final typeCompare = a.reportType.index.compareTo(b.reportType.index);
@@ -217,6 +219,10 @@ class _ReportListViewState extends ConsumerState<ReportListView> {
         continue;
       }
 
+      final currentProgressWeek = findCurrentProgressWeek(
+        typeReports,
+        now: currentTime,
+      );
       final weekGroups = <_WeekGroup>[];
       final weeks = typeReports.map((report) => report.week).toSet().toList()
         ..sort();
@@ -227,14 +233,11 @@ class _ReportListViewState extends ConsumerState<ReportListView> {
             .toList(growable: false)
           ..sort((a, b) => a.seq.compareTo(b.seq));
 
-        final hasProgress = weekReports.any(
-          (report) => report.endAt.isAfter(DateTime.now().toUtc()),
-        );
-
         weekGroups.add(
           _WeekGroup(
             week: week,
-            isProgress: hasProgress,
+            isProgress:
+                currentProgressWeek != null && week == currentProgressWeek,
             reports: weekReports,
           ),
         );
@@ -533,11 +536,13 @@ class _WeekGroupCard extends StatelessWidget {
                 fontWeight: FontWeight.w700,
               ),
             ),
-            const SizedBox(width: 8),
-            _WeekStatusBadge(
-              isProgress: weekGroup.isProgress,
-              palette: palette,
-            ),
+            if (weekGroup.isProgress) ...[
+              const SizedBox(width: 8),
+              _WeekStatusBadge(
+                isProgress: weekGroup.isProgress,
+                palette: palette,
+              ),
+            ],
           ],
         ),
         children: [
@@ -572,37 +577,21 @@ class _WeekStatusBadge extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (isProgress) {
-      return Container(
-        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
-        decoration: BoxDecoration(
-          color: const Color(0xFFECFDF3),
-          borderRadius: BorderRadius.circular(6),
-          border: Border.all(color: const Color(0xFFA7F3D0)),
-        ),
-        child: const Text(
-          '진행중',
-          style: TextStyle(
-            color: Color(0xFF059669),
-            fontSize: 10,
-            fontWeight: FontWeight.w700,
-            letterSpacing: 0.7,
-          ),
-        ),
-      );
+    if (!isProgress) {
+      return const SizedBox.shrink();
     }
 
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
       decoration: BoxDecoration(
-        color: palette.doneBadgeBackground,
+        color: const Color(0xFFECFDF3),
         borderRadius: BorderRadius.circular(6),
-        border: Border.all(color: palette.doneBadgeBorder),
+        border: Border.all(color: const Color(0xFFA7F3D0)),
       ),
-      child: Text(
-        '종료',
+      child: const Text(
+        '진행중',
         style: TextStyle(
-          color: palette.doneBadgeText,
+          color: Color(0xFF059669),
           fontSize: 10,
           fontWeight: FontWeight.w700,
           letterSpacing: 0.7,

--- a/lib/src/feature/reports/ui/widgets/report_list_widget.dart
+++ b/lib/src/feature/reports/ui/widgets/report_list_widget.dart
@@ -1,5 +1,6 @@
 import 'package:a_and_i_report_web_server/src/feature/home/data/entities/report_summary.dart';
 import 'package:a_and_i_report_web_server/src/core/widgets/responsive_layout.dart';
+import 'package:a_and_i_report_web_server/src/feature/reports/ui/utils/report_progress.dart';
 import 'package:a_and_i_report_web_server/src/feature/reports/ui/widgets/report_status_widget.dart';
 import 'package:a_and_i_report_web_server/src/feature/reports/ui/widgets/report_title_row.dart';
 import 'package:flutter/material.dart';
@@ -22,12 +23,7 @@ class ReportListWidget extends StatelessWidget {
 
   Widget _label(BuildContext context) {
     final isMobile = ResponsiveLayout.isMobile(context);
-    final weekStatus = reports.any(
-      (report) =>
-          ReportStatueType.fromEndAt(report.endAt) == ReportStatueType.progress,
-    )
-        ? ReportStatueType.progress
-        : ReportStatueType.done;
+    final currentProgressWeek = findCurrentProgressWeek(reports);
 
     return Padding(
       padding:
@@ -44,7 +40,8 @@ class ReportListWidget extends StatelessWidget {
               ),
             ),
           ),
-          ReportStatus(type: weekStatus),
+          if (currentProgressWeek != null)
+            const ReportStatus(type: ReportStatueType.progress),
         ],
       ),
     );

--- a/test/src/feature/reports/ui/utils/report_progress_test.dart
+++ b/test/src/feature/reports/ui/utils/report_progress_test.dart
@@ -1,0 +1,57 @@
+import 'package:a_and_i_report_web_server/src/feature/home/data/entities/level.dart';
+import 'package:a_and_i_report_web_server/src/feature/home/data/entities/report_summary.dart';
+import 'package:a_and_i_report_web_server/src/feature/home/data/entities/report_type.dart';
+import 'package:a_and_i_report_web_server/src/feature/reports/ui/utils/report_progress.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('findCurrentProgressWeek', () {
+    test('시작한 과제 중 가장 최신 주차를 진행 중으로 본다', () {
+      final now = DateTime.parse('2026-04-07T12:00:00Z');
+      final reports = [
+        _report(
+          week: 1,
+          startAt: DateTime.parse('2026-04-01T00:00:00Z'),
+        ),
+        _report(
+          week: 2,
+          startAt: DateTime.parse('2026-04-05T00:00:00Z'),
+        ),
+        _report(
+          week: 3,
+          startAt: DateTime.parse('2026-04-08T00:00:00Z'),
+        ),
+      ];
+
+      expect(findCurrentProgressWeek(reports, now: now), 2);
+    });
+
+    test('시작한 과제가 없으면 진행 중 주차가 없다', () {
+      final now = DateTime.parse('2026-04-07T12:00:00Z');
+      final reports = [
+        _report(
+          week: 3,
+          startAt: DateTime.parse('2026-04-08T00:00:00Z'),
+        ),
+      ];
+
+      expect(findCurrentProgressWeek(reports, now: now), isNull);
+    });
+  });
+}
+
+ReportSummary _report({
+  required int week,
+  DateTime? startAt,
+}) {
+  return ReportSummary(
+    id: 'report-$week',
+    week: week,
+    seq: 1,
+    title: 'Report $week',
+    level: Level.LOW,
+    reportType: ReportType.CS,
+    startAt: startAt,
+    endAt: DateTime.parse('2026-04-30T00:00:00Z'),
+  );
+}


### PR DESCRIPTION
## 변경 내용 (What)

- 과제 진행 주차 판정 기준을 endAt 중심에서 startAt 중심으로 변경했습니다.
- startAt이 지난 과제들 중 가장 최신 주차만 현재 진행 중인 주차로 표시되도록 수정했습니다.
- 진행 중이 아닌 주차의 종료 뱃지는 제거하고, 진행 중인 주차에만 진행중 뱃지가 보이도록 정리했습니다.
- ReportSummary에 startAt을 반영하고 관련 테스트를 추가했습니다.

## 확인 방법 (How to check)

- 과제 목록 페이지(/report?courseSlug=...)에 진입합니다.
- startAt이 현재 시각보다 이전인 과제들 중 가장 최신 주차에만 진행중 뱃지가 표시되는지 확인합니다.
- 그 외 주차에는 상태 뱃지가 보이지 않는지 확인합니다.
- flutter analyze
- flutter test test/src/feature/reports/ui/utils/report_progress_test.dart test/src/feature/reports/ui/
  widgets/report_status_widget_test.dart

## 체크리스트

- [x] PR 목적이 하나입니다 (한 PR = 한 목적)
- [x] 변경 범위를 최소화했습니다
- [ ] 문서/가이드가 필요하면 함께 업데이트했습니다
- [ ] (선택) 스크린샷/로그/요청·응답 예시를 첨부했습니다