### PR TITLE
fix(web): align v2 request handling with latest package workspace

### DIFF
--- a/lib/src/core/interceptors/api_interceptor.dart
+++ b/lib/src/core/interceptors/api_interceptor.dart
@@ -1,0 +1,146 @@
+import 'package:a_and_i_report_web_server/src/core/network/api_failure_exception.dart';
+import 'package:a_and_i_report_web_server/src/core/network/base_response.dart';
+import 'package:a_and_i_report_web_server/src/core/utils/app_messenger.dart';
+import 'package:a_and_i_report_web_server/src/feature/auth/data/datasources/local/local_auth_datasource.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+
+/// 공통 헤더 주입과 envelope 기반 에러 처리를 담당하는 Interceptor 입니다.
+class ApiInterceptor extends Interceptor {
+  static const _alertHandledKey = '__api_alert_handled__';
+
+  ApiInterceptor({
+    required this.localAuthDatasource,
+  });
+
+  final LocalAuthDatasource localAuthDatasource;
+
+  @override
+  Future<void> onRequest(
+    RequestOptions options,
+    RequestInterceptorHandler handler,
+  ) async {
+    options.headers.putIfAbsent('deviceOS', _resolveDeviceOs);
+    options.headers.putIfAbsent('timestamp', _resolveTimestamp);
+
+    final hasAuthorization = options.headers.keys.any(
+      (key) => key.toLowerCase() == 'authorization',
+    );
+    if (!hasAuthorization && !_isAuthEndpoint(options.path)) {
+      final accessToken = await localAuthDatasource.getUserToken();
+      if (accessToken != null && accessToken.trim().isNotEmpty) {
+        options.headers['Authorization'] = 'Bearer ${accessToken.trim()}';
+      }
+    }
+
+    handler.next(options);
+  }
+
+  @override
+  void onResponse(Response response, ResponseInterceptorHandler handler) {
+    final failure = _extractFailure(response);
+    if (failure != null) {
+      _showAlert(failure.error?.alert ?? failure.error?.message);
+      response.requestOptions.extra[_alertHandledKey] = true;
+
+      handler.reject(
+        DioException(
+          requestOptions: response.requestOptions,
+          response: response,
+          type: DioExceptionType.badResponse,
+          error: failure,
+          message: failure.message,
+        ),
+      );
+      return;
+    }
+
+    handler.next(response);
+  }
+
+  @override
+  void onError(DioException err, ErrorInterceptorHandler handler) {
+    final alreadyHandled = err.requestOptions.extra[_alertHandledKey] == true;
+    if (!alreadyHandled) {
+      final failure = _extractFailure(err.response);
+      final alert = failure?.error?.alert ?? _extractAlert(err.response?.data);
+      _showAlert(alert);
+      err.requestOptions.extra[_alertHandledKey] = true;
+    }
+
+    handler.next(err);
+  }
+
+  ApiFailureException? _extractFailure(Response<dynamic>? response) {
+    final data = response?.data;
+    if (data is! Map<String, dynamic>) {
+      return null;
+    }
+
+    final hasSuccess = data.containsKey('success');
+    if (!hasSuccess || data['success'] == true) {
+      return null;
+    }
+
+    return ApiFailureException(
+      statusCode: response?.statusCode,
+      error: BaseResponseError.fromNullableJson(data['error']),
+      timestamp: data['timestamp']?.toString(),
+    );
+  }
+
+  String? _extractAlert(Object? raw) {
+    if (raw is! Map<String, dynamic>) {
+      return null;
+    }
+
+    final error = raw['error'];
+    if (error is! Map<String, dynamic>) {
+      return null;
+    }
+
+    final alert = error['alert']?.toString().trim();
+    if (alert != null && alert.isNotEmpty) {
+      return alert;
+    }
+
+    final message = error['message']?.toString().trim();
+    if (message != null && message.isNotEmpty) {
+      return message;
+    }
+
+    return null;
+  }
+
+  void _showAlert(String? message) {
+    final normalized = message?.trim();
+    if (normalized == null || normalized.isEmpty) {
+      return;
+    }
+    showGlobalSnackBar(normalized);
+  }
+
+  bool _isAuthEndpoint(String path) {
+    final normalizedPath = Uri.tryParse(path)?.path ?? path;
+    return normalizedPath.startsWith('/v1/auth/');
+  }
+
+  String _resolveDeviceOs() {
+    if (kIsWeb) {
+      return 'web';
+    }
+
+    return switch (defaultTargetPlatform) {
+      TargetPlatform.android => 'android',
+      TargetPlatform.iOS => 'ios',
+      TargetPlatform.macOS => 'macos',
+      TargetPlatform.windows => 'windows',
+      TargetPlatform.linux => 'linux',
+      TargetPlatform.fuchsia => 'fuchsia',
+    };
+  }
+
+  String _resolveTimestamp() {
+    return DateTime.now().toIso8601String();
+  }
+}

--- a/lib/src/core/interceptors/api_interceptor.dart
+++ b/lib/src/core/interceptors/api_interceptor.dart
@@ -23,15 +23,18 @@ class ApiInterceptor extends Interceptor {
     options.headers.putIfAbsent('deviceOS', _resolveDeviceOs);
     options.headers.putIfAbsent('timestamp', _resolveTimestamp);
 
-    final hasAuthorization = options.headers.keys.any(
-      (key) => key.toLowerCase() == 'authorization',
-    );
-    if (!hasAuthorization && !_isAuthEndpoint(options.path)) {
+    final hasAuthenticationHeader = options.headers.keys.any((key) {
+      final normalized = key.toLowerCase();
+      return normalized == 'authorization' || normalized == 'authenticate';
+    });
+    if (!hasAuthenticationHeader && !_isAuthEndpoint(options.path)) {
       final accessToken = await localAuthDatasource.getUserToken();
       if (accessToken != null && accessToken.trim().isNotEmpty) {
-        options.headers['Authorization'] = 'Bearer ${accessToken.trim()}';
+        options.headers['Authenticate'] = 'Bearer ${accessToken.trim()}';
       }
     }
+
+    _normalizeAuthenticateHeader(options.headers);
 
     handler.next(options);
   }
@@ -122,7 +125,9 @@ class ApiInterceptor extends Interceptor {
 
   bool _isAuthEndpoint(String path) {
     final normalizedPath = Uri.tryParse(path)?.path ?? path;
-    return normalizedPath.startsWith('/v1/auth/');
+    return normalizedPath.startsWith('/v1/auth/') ||
+        normalizedPath.startsWith('/v2/auth/') ||
+        normalizedPath == '/v2/activate';
   }
 
   String _resolveDeviceOs() {
@@ -141,6 +146,37 @@ class ApiInterceptor extends Interceptor {
   }
 
   String _resolveTimestamp() {
-    return DateTime.now().toIso8601String();
+    return DateTime.now().toUtc().toIso8601String();
+  }
+
+  void _normalizeAuthenticateHeader(Map<String, dynamic> headers) {
+    final authorizationKey = headers.keys.firstWhere(
+      (key) => key.toLowerCase() == 'authorization',
+      orElse: () => '',
+    );
+    final authenticateKey = headers.keys.firstWhere(
+      (key) => key.toLowerCase() == 'authenticate',
+      orElse: () => '',
+    );
+
+    final rawValue =
+        (authenticateKey.isNotEmpty ? headers[authenticateKey] : null) ??
+        (authorizationKey.isNotEmpty ? headers[authorizationKey] : null);
+    final normalizedValue = rawValue?.toString().trim();
+    if (normalizedValue == null || normalizedValue.isEmpty) {
+      return;
+    }
+
+    if (authorizationKey.isNotEmpty) {
+      headers.remove(authorizationKey);
+    }
+    if (authenticateKey.isNotEmpty) {
+      headers.remove(authenticateKey);
+    }
+
+    headers['Authenticate'] =
+        normalizedValue.toLowerCase().startsWith('bearer ')
+            ? normalizedValue
+            : 'Bearer $normalizedValue';
   }
 }

--- a/lib/src/core/interceptors/auth_interceptor.dart
+++ b/lib/src/core/interceptors/auth_interceptor.dart
@@ -1,12 +1,12 @@
 import 'dart:developer';
-import 'package:aandi_api_endpoints/aandi_api_endpoints.dart';
 import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
 import 'package:a_and_i_report_web_server/src/feature/auth/data/datasources/local/local_auth_datasource.dart';
 
 /// 401 에러 발생 시 자동으로 토큰을 갱신하는 Dio Interceptor
 class AuthInterceptor extends QueuedInterceptor {
   static const _retryKey = '__auth_retry__';
-  static const _refreshPath = AandiApiEndpointTemplate.refreshToken;
+  static const _refreshPath = '/v2/auth/refresh';
 
   final LocalAuthDatasource localAuthDatasource;
   final Dio dio;
@@ -112,7 +112,11 @@ class AuthInterceptor extends QueuedInterceptor {
       _refreshPath,
       data: {'refreshToken': refreshToken},
       options: Options(
-        headers: {'Content-Type': 'application/json'},
+        headers: {
+          'Content-Type': 'application/json',
+          'deviceOS': _resolveDeviceOs(),
+          'timestamp': DateTime.now().toUtc().toIso8601String(),
+        },
       ),
     );
   }
@@ -162,7 +166,8 @@ class AuthInterceptor extends QueuedInterceptor {
 
   String? _readAuthorizationHeader(RequestOptions options) {
     for (final entry in options.headers.entries) {
-      if (entry.key.toLowerCase() != 'authorization') {
+      final key = entry.key.toLowerCase();
+      if (key != 'authorization' && key != 'authenticate') {
         continue;
       }
       final value = entry.value?.toString().trim();
@@ -175,16 +180,43 @@ class AuthInterceptor extends QueuedInterceptor {
   }
 
   void _setAuthorizationHeader(RequestOptions options, String value) {
-    final authorizationHeaderKey = options.headers.keys.firstWhere(
-      (key) => key.toLowerCase() == 'authorization',
-      orElse: () => 'Authorization',
+    final authenticateHeaderKey = options.headers.keys.firstWhere(
+      (key) {
+        final normalized = key.toLowerCase();
+        return normalized == 'authorization' || normalized == 'authenticate';
+      },
+      orElse: () => 'Authenticate',
     );
-    options.headers[authorizationHeaderKey] = value;
+    options.headers
+      ..removeWhere(
+        (key, _) =>
+            key.toLowerCase() == 'authorization' ||
+            key.toLowerCase() == 'authenticate',
+      )
+      ..[authenticateHeaderKey == 'Authorization'
+              ? 'Authenticate'
+              : authenticateHeaderKey] =
+          value;
   }
 
   RequestOptions _buildRetryOptions(RequestOptions source) {
     final data = source.data;
     final clonedData = data is FormData ? data.clone() : data;
     return source.copyWith(data: clonedData);
+  }
+
+  String _resolveDeviceOs() {
+    if (kIsWeb) {
+      return 'web';
+    }
+
+    return switch (defaultTargetPlatform) {
+      TargetPlatform.android => 'android',
+      TargetPlatform.iOS => 'ios',
+      TargetPlatform.macOS => 'macos',
+      TargetPlatform.windows => 'windows',
+      TargetPlatform.linux => 'linux',
+      TargetPlatform.fuchsia => 'fuchsia',
+    };
   }
 }

--- a/lib/src/core/network/api_failure_exception.dart
+++ b/lib/src/core/network/api_failure_exception.dart
@@ -1,0 +1,31 @@
+import 'package:a_and_i_report_web_server/src/core/network/base_response.dart';
+
+/// 공통 API envelope 실패를 표현하는 예외입니다.
+class ApiFailureException implements Exception {
+  const ApiFailureException({
+    this.statusCode,
+    this.error,
+    this.timestamp,
+  });
+
+  final int? statusCode;
+  final BaseResponseError? error;
+  final String? timestamp;
+
+  String get message {
+    final alert = error?.alert?.trim();
+    if (alert != null && alert.isNotEmpty) {
+      return alert;
+    }
+
+    final detail = error?.message?.trim();
+    if (detail != null && detail.isNotEmpty) {
+      return detail;
+    }
+
+    return '요청 처리 중 오류가 발생했습니다.';
+  }
+
+  @override
+  String toString() => message;
+}

--- a/lib/src/core/network/base_response.dart
+++ b/lib/src/core/network/base_response.dart
@@ -1,0 +1,67 @@
+/// 서버의 공통 응답 envelope 입니다.
+class BaseResponse<T> {
+  const BaseResponse({
+    required this.success,
+    this.data,
+    this.error,
+    this.timestamp,
+  });
+
+  final bool success;
+  final T? data;
+  final BaseResponseError? error;
+  final String? timestamp;
+
+  factory BaseResponse.fromJson(
+    Map<String, dynamic> json,
+    T? Function(Object? rawData) fromData,
+  ) {
+    return BaseResponse<T>(
+      success: json['success'] == true,
+      data: fromData(json['data']),
+      error: BaseResponseError.fromNullableJson(json['error']),
+      timestamp: json['timestamp']?.toString(),
+    );
+  }
+}
+
+/// 서버의 공통 에러 payload 입니다.
+class BaseResponseError {
+  const BaseResponseError({
+    this.code,
+    this.message,
+    this.value,
+    this.alert,
+  });
+
+  final int? code;
+  final String? message;
+  final String? value;
+  final String? alert;
+
+  factory BaseResponseError.fromJson(Map<String, dynamic> json) {
+    return BaseResponseError(
+      code: _asInt(json['code']),
+      message: json['message']?.toString(),
+      value: json['value']?.toString(),
+      alert: json['alert']?.toString(),
+    );
+  }
+
+  static BaseResponseError? fromNullableJson(Object? raw) {
+    if (raw is! Map<String, dynamic>) {
+      return null;
+    }
+    return BaseResponseError.fromJson(raw);
+  }
+
+  static int? _asInt(Object? value) {
+    if (value is int) {
+      return value;
+    }
+    if (value is num) {
+      return value.toInt();
+    }
+    return int.tryParse(value?.toString() ?? '');
+  }
+}

--- a/lib/src/core/providers/dio_provider.dart
+++ b/lib/src/core/providers/dio_provider.dart
@@ -1,7 +1,6 @@
 import 'package:dio/dio.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
-import 'package:aandi_api_endpoints/aandi_api_endpoints.dart';
 import 'package:a_and_i_report_web_server/src/core/constants/api_url.dart';
 import 'package:a_and_i_report_web_server/src/core/interceptors/api_interceptor.dart';
 import 'package:a_and_i_report_web_server/src/core/interceptors/auth_interceptor.dart';
@@ -37,7 +36,7 @@ Dio dio(Ref ref) {
         if (refreshToken != null && refreshToken.isNotEmpty) {
           try {
             await dio.post(
-              AandiApiEndpointTemplate.logout,
+              '/v2/auth/logout',
               data: {'refreshToken': refreshToken},
               options: Options(
                 headers: {'Content-Type': 'application/json'},

--- a/lib/src/core/providers/dio_provider.dart
+++ b/lib/src/core/providers/dio_provider.dart
@@ -3,6 +3,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:aandi_api_endpoints/aandi_api_endpoints.dart';
 import 'package:a_and_i_report_web_server/src/core/constants/api_url.dart';
+import 'package:a_and_i_report_web_server/src/core/interceptors/api_interceptor.dart';
 import 'package:a_and_i_report_web_server/src/core/interceptors/auth_interceptor.dart';
 import 'package:a_and_i_report_web_server/src/core/utils/app_messenger.dart';
 import 'package:a_and_i_report_web_server/src/feature/auth/providers/local_auth_datasource_provider.dart';
@@ -21,6 +22,12 @@ Dio dio(Ref ref) {
   final dio = Dio(BaseOptions(
     baseUrl: baseUrl,
   ));
+
+  dio.interceptors.add(
+    ApiInterceptor(
+      localAuthDatasource: localAuthDatasource,
+    ),
+  );
 
   dio.interceptors.add(
     AuthInterceptor(

--- a/lib/src/core/providers/dio_provider.g.dart
+++ b/lib/src/core/providers/dio_provider.g.dart
@@ -6,7 +6,7 @@ part of 'dio_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$dioHash() => r'd90f5eacb212457f1a967b467f520789744f8881';
+String _$dioHash() => r'ae449065e1b61353d0403533e35d1add2a3e5ed5';
 
 /// HTTP 통신을 위한 [Dio] 인스턴스를 제공하는 Provider입니다.
 ///

--- a/lib/src/core/providers/package_api_client_providers.dart
+++ b/lib/src/core/providers/package_api_client_providers.dart
@@ -1,0 +1,14 @@
+import 'package:a_and_i_report_web_server/src/core/constants/api_url.dart';
+import 'package:aandi_course_api/aandi_course_api.dart';
+import 'package:aandi_oj_api/aandi_oj_api.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+/// 외부 공통 API 패키지의 코스 클라이언트를 제공합니다.
+final courseApiClientProvider = Provider<CourseApiClient>((ref) {
+  return CourseApiClient(baseUrl: baseUrl);
+});
+
+/// 외부 공통 API 패키지의 OJ 클라이언트를 제공합니다.
+final ojApiClientProvider = Provider<OjApiClient>((ref) {
+  return OjApiClient(baseUrl: baseUrl);
+});

--- a/lib/src/core/utils/api_error_mapper.dart
+++ b/lib/src/core/utils/api_error_mapper.dart
@@ -1,3 +1,4 @@
+import 'package:a_and_i_report_web_server/src/core/network/api_failure_exception.dart';
 import 'package:dio/dio.dart';
 
 /// API/네트워크 예외를 사용자 노출용 메시지로 변환합니다.
@@ -9,21 +10,39 @@ final class ApiErrorMapper {
     Object error, {
     String fallbackMessage = '오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
   }) {
+    if (error is ApiFailureException) {
+      return mapApiError(
+        code: error.error?.code?.toString(),
+        value: error.error?.value,
+        message: error.error?.message,
+        alert: error.error?.alert,
+        fallbackMessage: fallbackMessage,
+      );
+    }
+
     if (error is DioException) {
       return _mapDioException(error, fallbackMessage: fallbackMessage);
     }
 
-    final normalized = error.toString().replaceFirst(RegExp(r'^Exception:\s*'), '');
+    final normalized =
+        error.toString().replaceFirst(RegExp(r'^Exception:\s*'), '');
     return normalized.isEmpty ? fallbackMessage : normalized;
   }
 
   /// 서버 에러 코드와 메시지를 사용자 메시지로 변환합니다.
   static String mapApiError({
     String? code,
+    String? value,
     String? message,
+    String? alert,
     String fallbackMessage = '요청 처리 중 오류가 발생했습니다.',
   }) {
-    final normalizedCode = code?.trim().toUpperCase();
+    final normalizedAlert = alert?.trim();
+    if (normalizedAlert != null && normalizedAlert.isNotEmpty) {
+      return normalizedAlert;
+    }
+
+    final normalizedCode = (value ?? code)?.trim().toUpperCase();
     final normalizedMessage = message?.trim();
 
     return switch (normalizedCode) {
@@ -34,7 +53,8 @@ final class ApiErrorMapper {
       'ENUM_MISMATCH_STATUS' ||
       'ENUM_MISMATCH_TRACK' ||
       'MISSING_REQUIRED_VALUE' ||
-      'BAD_REQUEST' => '요청 값이 올바르지 않습니다.',
+      'BAD_REQUEST' =>
+        '요청 값이 올바르지 않습니다.',
       'UNAUTHORIZED' => '로그인이 필요하거나 인증이 만료되었습니다.',
       'FORBIDDEN' => '요청을 수행할 권한이 없습니다.',
       'NOT_FOUND' => normalizedMessage?.isNotEmpty == true
@@ -47,7 +67,9 @@ final class ApiErrorMapper {
           ? normalizedMessage!
           : '요청은 유효하지만 처리할 수 없습니다.',
       'INTERNAL_SERVER_ERROR' => '서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
-      _ => normalizedMessage?.isNotEmpty == true ? normalizedMessage! : fallbackMessage,
+      _ => normalizedMessage?.isNotEmpty == true
+          ? normalizedMessage!
+          : fallbackMessage,
     };
   }
 
@@ -61,13 +83,21 @@ final class ApiErrorMapper {
 
     final data = error.response?.data;
     final errorMap = data is Map<String, dynamic> ? data['error'] : null;
-    final code = errorMap is Map<String, dynamic> ? errorMap['code']?.toString() : null;
+    final code =
+        errorMap is Map<String, dynamic> ? errorMap['code']?.toString() : null;
+    final value =
+        errorMap is Map<String, dynamic> ? errorMap['value']?.toString() : null;
     final message = errorMap is Map<String, dynamic>
         ? errorMap['message']?.toString()
         : null;
-    final topLevelError = data is Map<String, dynamic> ? data['error']?.toString() : null;
-    final requestId = data is Map<String, dynamic> ? data['requestId']?.toString() : null;
-    final resolvedMessage = message?.isNotEmpty == true ? message : topLevelError;
+    final alert =
+        errorMap is Map<String, dynamic> ? errorMap['alert']?.toString() : null;
+    final topLevelError =
+        data is Map<String, dynamic> ? data['error']?.toString() : null;
+    final requestId =
+        data is Map<String, dynamic> ? data['requestId']?.toString() : null;
+    final resolvedMessage =
+        message?.isNotEmpty == true ? message : topLevelError;
     final fallbackWithRequestId = requestId?.isNotEmpty == true
         ? '$fallbackMessage (requestId: $requestId)'
         : fallbackMessage;
@@ -77,7 +107,9 @@ final class ApiErrorMapper {
       return switch (statusCode) {
         400 => mapApiError(
             code: code,
+            value: value,
             message: resolvedMessage,
+            alert: alert,
             fallbackMessage: requestId?.isNotEmpty == true
                 ? '요청 값이 올바르지 않습니다. (requestId: $requestId)'
                 : '요청 값이 올바르지 않습니다.',
@@ -96,7 +128,9 @@ final class ApiErrorMapper {
         500 => '서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
         _ => mapApiError(
             code: code,
+            value: value,
             message: resolvedMessage,
+            alert: alert,
             fallbackMessage: fallbackWithRequestId,
           ),
       };
@@ -104,7 +138,9 @@ final class ApiErrorMapper {
 
     return mapApiError(
       code: code,
+      value: value,
       message: resolvedMessage,
+      alert: alert,
       fallbackMessage: fallbackWithRequestId,
     );
   }

--- a/lib/src/feature/activate/data/datasources/activate_remote_datasource.dart
+++ b/lib/src/feature/activate/data/datasources/activate_remote_datasource.dart
@@ -1,4 +1,3 @@
-import 'package:aandi_api_endpoints/aandi_api_endpoints.dart';
 import 'package:a_and_i_report_web_server/src/feature/activate/data/dtos/activate_request_dto.dart';
 import 'package:a_and_i_report_web_server/src/feature/activate/data/dtos/activate_response_dto.dart';
 import 'package:dio/dio.dart';
@@ -17,7 +16,7 @@ class ActivateRemoteDatasource {
   final String _baseUrl;
 
   Future<void> activate(ActivateRequestDto request) async {
-    const endpoints = AandiApiEndpointTemplate.activateCandidates;
+    const endpoints = <String>['/v2/activate', '/activate', '/v1/auth/activate'];
     for (var i = 0; i < endpoints.length; i++) {
       final endpoint = endpoints[i];
       final isLastEndpoint = i == endpoints.length - 1;
@@ -49,7 +48,11 @@ class ActivateRemoteDatasource {
   }
 
   String _buildUrl(String endpoint) {
-    return AandiApiUrlResolver.resolve(_baseUrl, endpoint);
+    if (_baseUrl.trim().isEmpty) {
+      return endpoint;
+    }
+
+    return Uri.parse(_baseUrl).resolve(endpoint).toString();
   }
 
   bool _isNetworkError(DioException error) {

--- a/lib/src/feature/articles/data/datasources/collaborator_lookup_remote_datasource.dart
+++ b/lib/src/feature/articles/data/datasources/collaborator_lookup_remote_datasource.dart
@@ -1,6 +1,6 @@
-import 'package:aandi_api_endpoints/aandi_api_endpoints.dart';
 import 'package:a_and_i_report_web_server/src/feature/articles/data/dtos/collaborator_lookup_response_dto.dart';
 import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
 
 /// 협업자 조회 원격 데이터소스 인터페이스입니다.
 abstract class CollaboratorLookupRemoteDatasource {
@@ -15,7 +15,7 @@ abstract class CollaboratorLookupRemoteDatasource {
 class CollaboratorLookupRemoteDatasourceImpl
     implements CollaboratorLookupRemoteDatasource {
   /// 협업자 조회 원격 데이터소스 구현체를 생성합니다.
-  const CollaboratorLookupRemoteDatasourceImpl(this._dio);
+  CollaboratorLookupRemoteDatasourceImpl(this._dio);
 
   final Dio _dio;
 
@@ -25,25 +25,31 @@ class CollaboratorLookupRemoteDatasourceImpl
     String code,
   ) async {
     try {
-      final response = await _dio.get<Map<String, dynamic>>(
-        AandiApiEndpointTemplate.userLookup,
-        queryParameters: <String, dynamic>{
-          'code': code,
-        },
+      final response = await _dio.requestUri<Map<String, dynamic>>(
+        Uri.parse('${_dio.options.baseUrl}/v2/users/lookup').replace(
+          queryParameters: <String, dynamic>{'code': code},
+        ),
         options: Options(
-          contentType: 'application/json',
+          method: 'GET',
           headers: <String, dynamic>{
-            'Authorization': authorization,
+            'Authenticate': authorization,
+            'deviceOS': _resolveDeviceOs(),
+            'timestamp': DateTime.now().toIso8601String(),
           },
         ),
       );
 
-      final responseData = response.data ?? <String, dynamic>{};
-      final payload = _extractPayload(responseData);
-      if (payload == null) {
-        return null;
+      final body = response.data;
+      if (body == null) {
+        throw Exception('협업자 조회 응답이 비어 있습니다.');
       }
-      return CollaboratorLookupResponseDto.fromJson(payload);
+
+      final data = body['data'];
+      if (data is! Map<String, dynamic>) {
+        throw Exception('협업자 조회 응답 형식이 올바르지 않습니다.');
+      }
+
+      return CollaboratorLookupResponseDto.fromJson(data);
     } on DioException catch (error) {
       if (error.response?.statusCode == 404) {
         return null;
@@ -52,14 +58,17 @@ class CollaboratorLookupRemoteDatasourceImpl
     }
   }
 
-  Map<String, dynamic>? _extractPayload(Map<String, dynamic> responseData) {
-    final data = responseData['data'];
-    if (data is Map<String, dynamic>) {
-      return data;
+  static String _resolveDeviceOs() {
+    if (kIsWeb) {
+      return 'web';
     }
-    if (data is Map) {
-      return Map<String, dynamic>.from(data);
-    }
-    return null;
+    return switch (defaultTargetPlatform) {
+      TargetPlatform.android => 'android',
+      TargetPlatform.iOS => 'ios',
+      TargetPlatform.macOS => 'macos',
+      TargetPlatform.windows => 'windows',
+      TargetPlatform.linux => 'linux',
+      TargetPlatform.fuchsia => 'fuchsia',
+    };
   }
 }

--- a/lib/src/feature/articles/data/datasources/image_remote_datasource.dart
+++ b/lib/src/feature/articles/data/datasources/image_remote_datasource.dart
@@ -1,6 +1,7 @@
-import 'package:aandi_api_endpoints/aandi_api_endpoints.dart';
 import 'package:a_and_i_report_web_server/src/feature/articles/data/dtos/image_upload_response_dto.dart';
+import 'package:aandi_tech_blog/aandi_tech_blog.dart' as blog_api;
 import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
 
 /// 이미지 업로드 원격 데이터소스입니다.
 abstract class ImageRemoteDatasource {
@@ -14,42 +15,54 @@ abstract class ImageRemoteDatasource {
 /// 이미지 업로드 원격 데이터소스 구현체입니다.
 class ImageRemoteDatasourceImpl implements ImageRemoteDatasource {
   /// 이미지 업로드 원격 데이터소스 구현체를 생성합니다.
-  const ImageRemoteDatasourceImpl(this.dio);
+  ImageRemoteDatasourceImpl(this.dio)
+    : _client = blog_api.TechBlogApiClient(
+        baseUrl: dio.options.baseUrl,
+        dio: dio,
+        deviceOs: _resolveDeviceOs(),
+      );
 
   /// HTTP 클라이언트입니다.
   final Dio dio;
+  final blog_api.TechBlogApiClient _client;
 
   @override
   Future<ImageUploadResponseDto> uploadImage({
     required String authorization,
     required MultipartFile file,
   }) async {
-    final formData = FormData.fromMap(<String, dynamic>{
-      'file': file,
-    });
-
-    final response = await dio.post<Map<String, dynamic>>(
-      AandiApiEndpointTemplate.postImages,
-      data: formData,
-      options: Options(
-        headers: <String, dynamic>{
-          'Authorization': authorization,
-        },
-      ),
+    final response = await _client.uploadImageV2(
+      accessToken: _extractAccessToken(authorization),
+      file: file,
     );
 
-    final responseData = response.data ?? <String, dynamic>{};
-    return ImageUploadResponseDto.fromJson(_extractPayload(responseData));
+    return ImageUploadResponseDto(
+      url: response.url,
+      key: response.key,
+      contentType: response.contentType ?? '',
+      size: response.size ?? 0,
+    );
   }
 
-  Map<String, dynamic> _extractPayload(Map<String, dynamic> responseData) {
-    final data = responseData['data'];
-    if (data is Map<String, dynamic>) {
-      return data;
+  String _extractAccessToken(String authorization) {
+    final normalized = authorization.trim();
+    if (normalized.toLowerCase().startsWith('bearer ')) {
+      return normalized.substring(7).trim();
     }
-    if (data is Map) {
-      return Map<String, dynamic>.from(data);
+    return normalized;
+  }
+
+  static String _resolveDeviceOs() {
+    if (kIsWeb) {
+      return 'web';
     }
-    return responseData;
+    return switch (defaultTargetPlatform) {
+      TargetPlatform.android => 'android',
+      TargetPlatform.iOS => 'ios',
+      TargetPlatform.macOS => 'macos',
+      TargetPlatform.windows => 'windows',
+      TargetPlatform.linux => 'linux',
+      TargetPlatform.fuchsia => 'fuchsia',
+    };
   }
 }

--- a/lib/src/feature/articles/data/datasources/post_remote_datasource.dart
+++ b/lib/src/feature/articles/data/datasources/post_remote_datasource.dart
@@ -1,16 +1,17 @@
-import 'dart:convert';
-
-import 'package:aandi_api_endpoints/aandi_api_endpoints.dart';
+import 'package:a_and_i_report_web_server/src/feature/articles/data/dtos/post_author_response_dto.dart';
 import 'package:a_and_i_report_web_server/src/feature/articles/data/dtos/post_list_response_dto.dart';
 import 'package:a_and_i_report_web_server/src/feature/articles/data/dtos/post_response_dto.dart';
 import 'package:a_and_i_report_web_server/src/feature/articles/domain/entities/post_author.dart';
 import 'package:a_and_i_report_web_server/src/feature/articles/domain/entities/post_type.dart';
+import 'package:aandi_tech_blog/aandi_tech_blog.dart' as blog_api;
 import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
 
 /// 게시글 원격 데이터소스입니다.
 abstract class PostRemoteDatasource {
   /// 서버에서 게시글 목록을 조회합니다.
   Future<PostListResponseDto> getPosts(
+    String? authorization,
     int page,
     int size,
     PostType? type,
@@ -34,8 +35,8 @@ abstract class PostRemoteDatasource {
 
   /// 서버에서 게시글 상세를 조회합니다.
   Future<PostResponseDto> getPost(
+    String? authorization,
     String postId,
-    PostType type,
   );
 
   /// 서버의 게시글을 일부 수정합니다.
@@ -66,39 +67,47 @@ abstract class PostRemoteDatasource {
 /// 게시글 원격 데이터소스 구현체입니다.
 class PostRemoteDatasourceImpl implements PostRemoteDatasource {
   /// 게시글 원격 데이터소스 구현체를 생성합니다.
-  const PostRemoteDatasourceImpl(this.dio);
+  PostRemoteDatasourceImpl(this.dio)
+    : _client = blog_api.TechBlogApiClient(
+        baseUrl: dio.options.baseUrl,
+        dio: dio,
+        deviceOs: _resolveDeviceOs(),
+      );
 
   /// HTTP 클라이언트입니다.
   final Dio dio;
+  final blog_api.TechBlogApiClient _client;
 
   @override
   Future<PostListResponseDto> getPosts(
+    String? authorization,
     int page,
     int size,
     PostType? type,
     String? status,
   ) async {
-    final queryParameters = <String, dynamic>{
-      'page': page,
-      'size': size,
-    };
-    if (status != null && status.isNotEmpty) {
-      queryParameters['status'] = status;
-    }
-    if (type != null) {
-      queryParameters['type'] = type.apiValue;
-    }
-
-    final response = await dio.get<Map<String, dynamic>>(
-      AandiApiEndpointTemplate.posts,
-      queryParameters: queryParameters,
-      options: Options(
-        contentType: 'application/json',
-      ),
-    );
-
-    final responseData = response.data ?? <String, dynamic>{};
-    return PostListResponseDto.fromJson(_extractPayload(responseData));
+    final normalizedAuthorization = authorization?.trim();
+    final response =
+        normalizedAuthorization == null || normalizedAuthorization.isEmpty
+            ? await _client.listPosts(
+              page: page,
+              size: size,
+              status:
+                  status == null || status.isEmpty
+                      ? null
+                      : _toBlogStatus(status),
+            )
+            : await _client.listPostsV2(
+              accessToken: _extractAccessToken(normalizedAuthorization),
+              page: page,
+              size: size,
+              status:
+                  status == null || status.isEmpty
+                      ? null
+                      : _toBlogStatus(status),
+              type: _toBlogType(type),
+            );
+    return _toPostListResponseDto(response, type);
   }
 
   @override
@@ -115,58 +124,37 @@ class PostRemoteDatasourceImpl implements PostRemoteDatasource {
     List<PostAuthor> collaborators,
     MultipartFile? thumbnail,
   ) async {
-    final postJson = <String, dynamic>{
-      'type': type.apiValue,
-      'title': title,
-      'contentMarkdown': contentMarkdown,
-      if (summary != null) 'summary': summary,
-      'author': <String, dynamic>{
-        'id': authorId,
-        'nickname': authorNickname,
-        if (authorProfileImageUrl != null && authorProfileImageUrl.isNotEmpty)
-          'profileImageUrl': authorProfileImageUrl,
-      },
-      if (collaborators.isNotEmpty)
-        'collaborators': _toCollaboratorJson(collaborators),
-      if (status != null && status.isNotEmpty) 'status': status,
-    };
-    final formDataMap = <String, dynamic>{
-      'post': MultipartFile.fromString(
-        jsonEncode(postJson),
-        filename: 'post.json',
-        contentType: DioMediaType.parse('application/json'),
+    final response = await _client.createPostV2(
+      accessToken: _extractAccessToken(authorization),
+      post: blog_api.CreatePostRequest(
+        title: title,
+        author: blog_api.PostAuthor(
+          id: authorId,
+          nickname: authorNickname,
+          profileImageUrl: authorProfileImageUrl,
+        ),
+        summary: summary,
+        contentMarkdown: contentMarkdown,
+        collaborators: collaborators.map(_toBlogAuthor).toList(),
+        type: _toBlogType(type),
+        status: status == null || status.isEmpty ? null : _toBlogStatus(status),
       ),
-      if (thumbnail != null) 'thumbnail': thumbnail,
-    };
-
-    final response = await dio.post<Map<String, dynamic>>(
-      AandiApiEndpointTemplate.posts,
-      data: FormData.fromMap(formDataMap),
-      options: Options(
-        headers: <String, dynamic>{
-          'Authorization': authorization,
-        },
-      ),
+      thumbnail: thumbnail,
     );
-
-    final responseData = response.data ?? <String, dynamic>{};
-    return PostResponseDto.fromJson(_extractPayload(responseData));
+    return _toPostResponseDto(response);
   }
 
   @override
-  Future<PostResponseDto> getPost(String postId, PostType type) async {
-    final response = await dio.get<Map<String, dynamic>>(
-      AandiApiEndpointPath.postById(postId),
-      queryParameters: <String, dynamic>{
-        'type': type.apiValue,
-      },
-      options: Options(
-        contentType: 'application/json',
-      ),
-    );
-
-    final responseData = response.data ?? <String, dynamic>{};
-    return PostResponseDto.fromJson(_extractPayload(responseData));
+  Future<PostResponseDto> getPost(String? authorization, String postId) async {
+    final normalizedAuthorization = authorization?.trim();
+    final response =
+        normalizedAuthorization == null || normalizedAuthorization.isEmpty
+            ? await _client.getPost(postId: postId)
+            : await _client.getPostV2(
+              postId: postId,
+              accessToken: _extractAccessToken(normalizedAuthorization),
+            );
+    return _toPostResponseDto(response);
   }
 
   @override
@@ -181,49 +169,30 @@ class PostRemoteDatasourceImpl implements PostRemoteDatasource {
     List<PostAuthor> collaborators,
     MultipartFile? thumbnail,
   ) async {
-    final postJson = <String, dynamic>{
-      if (type != null) 'type': type.apiValue,
-      if (title != null && title.isNotEmpty) 'title': title,
-      if (contentMarkdown != null && contentMarkdown.isNotEmpty)
-        'contentMarkdown': contentMarkdown,
-      if (summary != null) 'summary': summary,
-      if (collaborators.isNotEmpty)
-        'collaborators': _toCollaboratorJson(collaborators),
-      if (status != null && status.isNotEmpty) 'status': status,
-    };
-    final formDataMap = <String, dynamic>{
-      'post': MultipartFile.fromString(
-        jsonEncode(postJson),
-        filename: 'post.json',
-        contentType: DioMediaType.parse('application/json'),
+    final response = await _client.patchPostV2(
+      postId: postId,
+      accessToken: _extractAccessToken(authorization),
+      post: blog_api.PatchPostRequest(
+        title: title,
+        summary: summary,
+        contentMarkdown: contentMarkdown,
+        collaborators:
+            collaborators.isEmpty
+                ? null
+                : collaborators.map(_toBlogAuthor).toList(),
+        type: _toBlogType(type),
+        status: status == null || status.isEmpty ? null : _toBlogStatus(status),
       ),
-      if (thumbnail != null) 'thumbnail': thumbnail,
-    };
-
-    final response = await dio.patch<Map<String, dynamic>>(
-      AandiApiEndpointPath.postById(postId),
-      data: FormData.fromMap(formDataMap),
-      options: Options(
-        headers: <String, dynamic>{
-          'Authorization': authorization,
-        },
-      ),
+      thumbnail: thumbnail,
     );
-
-    final responseData = response.data ?? <String, dynamic>{};
-    return PostResponseDto.fromJson(_extractPayload(responseData));
+    return _toPostResponseDto(response);
   }
 
   @override
   Future<void> deletePost(String authorization, String postId) async {
-    await dio.delete<void>(
-      AandiApiEndpointPath.postById(postId),
-      options: Options(
-        contentType: 'application/json',
-        headers: <String, dynamic>{
-          'Authorization': authorization,
-        },
-      ),
+    await _client.deletePostV2(
+      postId: postId,
+      accessToken: _extractAccessToken(authorization),
     );
   }
 
@@ -234,49 +203,113 @@ class PostRemoteDatasourceImpl implements PostRemoteDatasource {
     int size,
     PostType? type,
   ) async {
-    final queryParameters = <String, dynamic>{
-      'page': page,
-      'size': size,
-    };
-    if (type != null) {
-      queryParameters['type'] = type.apiValue;
-    }
-
-    final response = await dio.get<Map<String, dynamic>>(
-      AandiApiEndpointTemplate.myDraftPosts,
-      queryParameters: queryParameters,
-      options: Options(
-        contentType: 'application/json',
-        headers: <String, dynamic>{
-          'Authorization': authorization,
-        },
-      ),
+    final response = await _client.listMyDraftsV2(
+      accessToken: _extractAccessToken(authorization),
+      page: page,
+      size: size,
+      type: _toBlogType(type),
     );
-
-    final responseData = response.data ?? <String, dynamic>{};
-    return PostListResponseDto.fromJson(_extractPayload(responseData));
+    return _toPostListResponseDto(response, type);
   }
 
-  Map<String, dynamic> _extractPayload(Map<String, dynamic> responseData) {
-    final data = responseData['data'];
-    if (data is Map<String, dynamic>) {
-      return data;
-    }
-    if (data is Map) {
-      return Map<String, dynamic>.from(data);
-    }
-    return responseData;
+  PostListResponseDto _toPostListResponseDto(
+    blog_api.PagedPostResponse page,
+    PostType? requestedType,
+  ) {
+    final filteredItems =
+        page.items.where((post) {
+          final type = post.type ?? blog_api.PostType.blog;
+          return _matchesRequestedType(type, requestedType);
+        }).toList();
+    return PostListResponseDto(
+      items: filteredItems.map(_toPostResponseDto).toList(),
+      page: page.page,
+      size: page.size,
+      totalElements:
+          filteredItems.length == page.items.length
+              ? page.totalElements
+              : filteredItems.length,
+      totalPages: page.totalPages,
+    );
   }
 
-  List<Map<String, dynamic>> _toCollaboratorJson(
-      List<PostAuthor> collaborators) {
-    return collaborators
-        .map((item) => <String, dynamic>{
-              'id': item.id,
-              'nickname': item.nickname,
-              if (item.profileImage != null && item.profileImage!.isNotEmpty)
-                'profileImageUrl': item.profileImage,
-            })
-        .toList();
+  PostResponseDto _toPostResponseDto(blog_api.PostResponse post) {
+    return PostResponseDto(
+      id: post.id,
+      type: (post.type ?? blog_api.PostType.blog).toApi(),
+      title: post.title,
+      contentMarkdown: post.contentMarkdown ?? '',
+      summary: post.summary,
+      thumbnailUrl: post.thumbnailUrl,
+      author: _toPostAuthorResponseDto(post.author),
+      collaborators:
+          post.collaborators.map(_toPostAuthorResponseDto).toList(),
+      status: post.status.toApi(),
+      createdAt: post.createdAt ?? DateTime.now(),
+      updatedAt: post.updatedAt ?? DateTime.now(),
+    );
+  }
+
+  PostAuthorResponseDto _toPostAuthorResponseDto(blog_api.PostAuthor author) {
+    return PostAuthorResponseDto(
+      id: author.id,
+      nickname: author.nickname ?? '',
+      profileImage: author.profileImageUrl,
+    );
+  }
+
+  blog_api.PostAuthor _toBlogAuthor(PostAuthor author) {
+    return blog_api.PostAuthor(
+      id: author.id,
+      nickname: author.nickname,
+      profileImageUrl: author.profileImage,
+    );
+  }
+
+  blog_api.PostType? _toBlogType(PostType? type) {
+    return switch (type) {
+      null => null,
+      PostType.blog => blog_api.PostType.blog,
+      PostType.lecture => blog_api.PostType.lecture,
+    };
+  }
+
+  blog_api.PostStatus _toBlogStatus(String value) {
+    return switch (value) {
+      'Draft' => blog_api.PostStatus.draft,
+      'Published' => blog_api.PostStatus.published,
+      'Deleted' => blog_api.PostStatus.deleted,
+      _ => blog_api.PostStatus.draft,
+    };
+  }
+
+  String _extractAccessToken(String authorization) {
+    final normalized = authorization.trim();
+    if (normalized.toLowerCase().startsWith('bearer ')) {
+      return normalized.substring(7).trim();
+    }
+    return normalized;
+  }
+
+  static String _resolveDeviceOs() {
+    if (kIsWeb) {
+      return 'web';
+    }
+    return switch (defaultTargetPlatform) {
+      TargetPlatform.android => 'android',
+      TargetPlatform.iOS => 'ios',
+      TargetPlatform.macOS => 'macos',
+      TargetPlatform.windows => 'windows',
+      TargetPlatform.linux => 'linux',
+      TargetPlatform.fuchsia => 'fuchsia',
+    };
+  }
+
+  bool _matchesRequestedType(blog_api.PostType type, PostType? requestedType) {
+    return switch (requestedType) {
+      null => true,
+      PostType.blog => type == blog_api.PostType.blog,
+      PostType.lecture => type == blog_api.PostType.lecture,
+    };
   }
 }

--- a/lib/src/feature/articles/data/repositories/post_repository_impl.dart
+++ b/lib/src/feature/articles/data/repositories/post_repository_impl.dart
@@ -33,8 +33,14 @@ class PostRepositoryImpl implements PostRepository {
     PostType? type,
     String? status,
   }) async {
-    final response =
-        await postRemoteDatasource.getPosts(page, size, type, status);
+    final authorization = await _resolveAuthorization();
+    final response = await postRemoteDatasource.getPosts(
+      authorization,
+      page,
+      size,
+      type,
+      status,
+    );
     return response.toEntity();
   }
 
@@ -68,7 +74,8 @@ class PostRepositoryImpl implements PostRepository {
     required String postId,
     required PostType type,
   }) async {
-    final response = await postRemoteDatasource.getPost(postId, type);
+    final authorization = await _resolveAuthorization();
+    final response = await postRemoteDatasource.getPost(authorization, postId);
     return response.toEntity();
   }
 

--- a/lib/src/feature/articles/data/repositories/post_repository_impl.dart
+++ b/lib/src/feature/articles/data/repositories/post_repository_impl.dart
@@ -33,7 +33,7 @@ class PostRepositoryImpl implements PostRepository {
     PostType? type,
     String? status,
   }) async {
-    final authorization = await _resolveAuthorization();
+    final authorization = await _readAuthorization();
     final response = await postRemoteDatasource.getPosts(
       authorization,
       page,
@@ -74,7 +74,7 @@ class PostRepositoryImpl implements PostRepository {
     required String postId,
     required PostType type,
   }) async {
-    final authorization = await _resolveAuthorization();
+    final authorization = await _readAuthorization();
     final response = await postRemoteDatasource.getPost(authorization, postId);
     return response.toEntity();
   }
@@ -146,10 +146,18 @@ class PostRepositoryImpl implements PostRepository {
   }
 
   Future<String> _resolveAuthorization() async {
+    final authorization = await _readAuthorization();
+    if (authorization == null || authorization.isEmpty) {
+      throw Exception('로그인이 필요합니다.');
+    }
+    return authorization;
+  }
+
+  Future<String?> _readAuthorization() async {
     final token = await localAuthDatasource.getUserToken();
     final normalizedToken = token?.trim();
     if (normalizedToken == null || normalizedToken.isEmpty) {
-      throw Exception('로그인이 필요합니다.');
+      return null;
     }
     if (normalizedToken.toLowerCase().startsWith('bearer ')) {
       return normalizedToken;

--- a/lib/src/feature/auth/data/datasources/remote/remote_auth_datasource.dart
+++ b/lib/src/feature/auth/data/datasources/remote/remote_auth_datasource.dart
@@ -1,73 +1,34 @@
-import 'package:aandi_auth/aandi_auth.dart' as auth_api;
-import 'package:a_and_i_report_web_server/src/core/models/user.dart';
 import 'package:a_and_i_report_web_server/src/feature/auth/data/dtos/login_request_dto.dart';
 import 'package:a_and_i_report_web_server/src/feature/auth/data/dtos/login_response_dto.dart';
+import 'package:dio/dio.dart' hide Headers;
+import 'package:retrofit/retrofit.dart';
 
-/// 인증 관련 원격 데이터소스다.
-class RemoteAuthDatasource {
-  /// v2 인증 API 클라이언트를 주입받아 생성한다.
-  RemoteAuthDatasource({
-    required auth_api.AuthRepository repository,
-  }) : _repository = repository;
+part 'remote_auth_datasource.g.dart';
 
-  final auth_api.AuthRepository _repository;
+@RestApi()
+abstract class RemoteAuthDatasource {
+  factory RemoteAuthDatasource(Dio dio, {String baseUrl}) =
+      _RemoteAuthDatasource;
 
-  /// `/v2/auth/login` 로그인 API를 호출한다.
-  Future<LoginResponseDto> login(LoginRequestDto dto) async {
-    final response = await _repository.loginV2(
-      username: dto.username,
-      password: dto.password,
-    );
+  /// 로그인 API
+  ///
+  ///
+  @POST("/v2/auth/login")
+  @Headers(<String, dynamic>{
+    'Content-Type': 'application/json',
+  })
+  Future<LoginResponseDto> login(@Body() LoginRequestDto dto);
 
-    return LoginResponseDto(
-      success: true,
-      data: LoginDataDto(
-        accessToken: response.tokens.accessToken,
-        refreshToken: response.tokens.refreshToken ?? '',
-        expiresIn: response.tokens.expiresIn,
-        tokenType: response.tokens.tokenType ?? 'Bearer',
-        forcePasswordChange: response.forcePasswordChange,
-        user: LoginUserDto(
-          id: response.user.id,
-          username: response.user.username,
-          role: response.user.role.toApi(),
-        ),
-      ),
-      error: null,
-      timestamp: null,
-    );
-  }
+  /// 내 정보 조회 API
+  @GET("/v2/me")
+  Future<dynamic> getMyInfo(
+    @Header("Authenticate") String authorization,
+  );
 
-  /// `/v2/me` 내 정보 조회 API를 호출한다.
-  Future<User> getMyInfo(String accessToken) async {
-    final _ = accessToken;
-    final response = await _repository.meV2();
-    return User(
-      id: response.id,
-      nickname: _resolveNickname(
-        nickname: response.nickname,
-        username: response.username,
-      ),
-      role: response.role.toApi(),
-      profileImageUrl: response.profileImageUrl,
-      publicCode: response.publicCode,
-    );
-  }
-}
-
-String _resolveNickname({
-  required String? nickname,
-  required String username,
-}) {
-  final trimmedNickname = nickname?.trim();
-  if (trimmedNickname != null && trimmedNickname.isNotEmpty) {
-    return trimmedNickname;
-  }
-
-  final trimmedUsername = username.trim();
-  if (trimmedUsername.isNotEmpty) {
-    return trimmedUsername;
-  }
-
-  return '동아리원';
+  /// 토큰 갱신 API
+  @POST("/v2/auth/refresh")
+  @Headers(<String, dynamic>{
+    'Content-Type': 'application/json',
+  })
+  Future<LoginResponseDto> refreshToken(@Body() Map<String, dynamic> body);
 }

--- a/lib/src/feature/auth/data/datasources/remote/remote_auth_datasource.g.dart
+++ b/lib/src/feature/auth/data/datasources/remote/remote_auth_datasource.g.dart
@@ -1,0 +1,135 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'remote_auth_datasource.dart';
+
+// **************************************************************************
+// RetrofitGenerator
+// **************************************************************************
+
+// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations,unused_element_parameter
+
+class _RemoteAuthDatasource implements RemoteAuthDatasource {
+  _RemoteAuthDatasource(this._dio, {this.baseUrl, this.errorLogger});
+
+  final Dio _dio;
+
+  String? baseUrl;
+
+  final ParseErrorLogger? errorLogger;
+
+  @override
+  Future<LoginResponseDto> login(LoginRequestDto dto) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{r'Content-Type': 'application/json'};
+    _headers.removeWhere((k, v) => v == null);
+    final _data = dto;
+    final _options = _setStreamType<LoginResponseDto>(
+      Options(
+        method: 'POST',
+        headers: _headers,
+        extra: _extra,
+        contentType: 'application/json',
+      )
+          .compose(
+            _dio.options,
+            '/v2/auth/login',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late LoginResponseDto _value;
+    try {
+      _value = LoginResponseDto.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
+  }
+
+  @override
+  Future<dynamic> getMyInfo(String authorization) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{r'Authenticate': authorization};
+    _headers.removeWhere((k, v) => v == null);
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<dynamic>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/me',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch(_options);
+    final _value = _result.data;
+    return _value;
+  }
+
+  @override
+  Future<LoginResponseDto> refreshToken(Map<String, dynamic> body) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{r'Content-Type': 'application/json'};
+    _headers.removeWhere((k, v) => v == null);
+    final _data = <String, dynamic>{};
+    _data.addAll(body);
+    final _options = _setStreamType<LoginResponseDto>(
+      Options(
+        method: 'POST',
+        headers: _headers,
+        extra: _extra,
+        contentType: 'application/json',
+      )
+          .compose(
+            _dio.options,
+            '/v2/auth/refresh',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late LoginResponseDto _value;
+    try {
+      _value = LoginResponseDto.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
+  }
+
+  RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
+    if (T != dynamic &&
+        !(requestOptions.responseType == ResponseType.bytes ||
+            requestOptions.responseType == ResponseType.stream)) {
+      if (T == String) {
+        requestOptions.responseType = ResponseType.plain;
+      } else {
+        requestOptions.responseType = ResponseType.json;
+      }
+    }
+    return requestOptions;
+  }
+
+  String _combineBaseUrls(String dioBaseUrl, String? baseUrl) {
+    if (baseUrl == null || baseUrl.trim().isEmpty) {
+      return dioBaseUrl;
+    }
+
+    final url = Uri.parse(baseUrl);
+
+    if (url.isAbsolute) {
+      return url.toString();
+    }
+
+    return Uri.parse(dioBaseUrl).resolveUri(url).toString();
+  }
+}

--- a/lib/src/feature/auth/data/repositories/auth_repository_impl.dart
+++ b/lib/src/feature/auth/data/repositories/auth_repository_impl.dart
@@ -58,7 +58,12 @@ class AuthRepositoryImpl implements AuthRepository {
 
   @override
   Future<User> getMyInfo(String accessToken) async {
-    return remoteAuthRepository.getMyInfo(accessToken);
+    final response = await remoteAuthRepository.getMyInfo(accessToken);
+    final user = _parseUser(response);
+    if (user == null) {
+      throw Exception('사용자 정보를 불러오지 못했습니다.');
+    }
+    return user;
   }
 
   @override
@@ -90,5 +95,46 @@ class AuthRepositoryImpl implements AuthRepository {
   @override
   Future<void> deleteCachedUser() async {
     await localAuthRepository.deleteCachedUserJson();
+  }
+
+  User? _parseUser(dynamic response) {
+    if (response is! Map<String, dynamic>) {
+      return null;
+    }
+
+    final responseData = response['data'];
+    if (responseData is! Map<String, dynamic>) {
+      return null;
+    }
+
+    final nestedUser = responseData['user'];
+    final userData =
+        nestedUser is Map<String, dynamic> ? nestedUser : responseData;
+
+    final id = userData['id']?.toString() ?? userData['userId']?.toString();
+    final role = userData['role']?.toString();
+    final nickname = userData['nickName']?.toString() ??
+        userData['nickname']?.toString() ??
+        userData['nick_name']?.toString() ??
+        userData['displayName']?.toString() ??
+        userData['username']?.toString();
+    if (id == null || role == null || nickname == null || nickname.isEmpty) {
+      return null;
+    }
+
+    final profileImage = userData['profileImageUrl']?.toString() ??
+        userData['profileImagePath']?.toString() ??
+        userData['profileImage']?.toString();
+    final publicCode = userData['publicCode']?.toString() ??
+        userData['public_code']?.toString() ??
+        userData['publiccode']?.toString();
+
+    return User(
+      id: id,
+      role: role,
+      nickname: nickname,
+      profileImageUrl: profileImage,
+      publicCode: publicCode,
+    );
   }
 }

--- a/lib/src/feature/auth/providers/remote_auth_datasource_provider.dart
+++ b/lib/src/feature/auth/providers/remote_auth_datasource_provider.dart
@@ -1,8 +1,6 @@
 import 'package:a_and_i_report_web_server/src/core/constants/api_url.dart';
-import 'package:a_and_i_report_web_server/src/feature/auth/data/datasources/local/auth_token_store_adapter.dart';
+import 'package:a_and_i_report_web_server/src/core/providers/dio_provider.dart';
 import 'package:a_and_i_report_web_server/src/feature/auth/data/datasources/remote/remote_auth_datasource.dart';
-import 'package:a_and_i_report_web_server/src/feature/auth/providers/local_auth_datasource_provider.dart';
-import 'package:aandi_auth/aandi_auth.dart' as auth_api;
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -11,11 +9,7 @@ part 'remote_auth_datasource_provider.g.dart';
 @riverpod
 RemoteAuthDatasource remoteAuthDatasource(Ref ref) {
   return RemoteAuthDatasource(
-    repository: auth_api.AuthRepositoryImpl(
-      apiClient: auth_api.AuthApiClient(baseUrl: baseUrl),
-      tokenStore: AuthTokenStoreAdapter(
-        localAuthDatasource: ref.read(localAuthDatasourceProvider),
-      ),
-    ),
+    ref.read(dioProvider),
+    baseUrl: baseUrl,
   );
 }

--- a/lib/src/feature/home/domain/usecases/get_course_by_slug_usecase.dart
+++ b/lib/src/feature/home/domain/usecases/get_course_by_slug_usecase.dart
@@ -1,6 +1,6 @@
 import 'package:a_and_i_report_web_server/src/feature/auth/domain/repositories/auth_repository.dart';
 import 'package:a_and_i_report_web_server/src/feature/home/data/entities/course.dart';
-import 'package:a_and_i_report_web_server/src/feature/home/data/repositories/course_repository.dart';
+import 'package:aandi_course_api/aandi_course_api.dart' as course_api;
 
 /// 코스 슬러그로 코스 상세 정보를 조회하는 UseCase 인터페이스입니다.
 abstract class GetCourseBySlugUsecase {
@@ -9,13 +9,13 @@ abstract class GetCourseBySlugUsecase {
 
 /// 코스 슬러그로 코스 상세 정보를 조회하는 UseCase 구현체입니다.
 final class GetCourseBySlugUsecaseImpl implements GetCourseBySlugUsecase {
-  final CourseRepository _courseRepository;
+  final course_api.CourseApiClient _courseApiClient;
   final AuthRepository _authRepository;
 
   const GetCourseBySlugUsecaseImpl({
-    required CourseRepository courseRepository,
+    required course_api.CourseApiClient courseApiClient,
     required AuthRepository authRepository,
-  })  : _courseRepository = courseRepository,
+  })  : _courseApiClient = courseApiClient,
         _authRepository = authRepository;
 
   @override
@@ -26,16 +26,43 @@ final class GetCourseBySlugUsecaseImpl implements GetCourseBySlugUsecase {
       throw Exception('인증되지 않은 사용자입니다. 로그인이 필요합니다.');
     }
 
-    final authorization = 'Bearer $token';
-    final response = await _courseRepository.getCourseBySlugFromCourses(
-      authorization,
-      courseSlug,
-    );
-
-    if (!response.success || response.data == null) {
-      throw Exception(response.error?.message ?? '코스 정보를 불러오지 못했습니다.');
+    try {
+      final course = await _courseApiClient.getCourseV2(
+        accessToken: token,
+        courseSlug: courseSlug,
+      );
+      return _toCourse(course);
+    } on course_api.CourseApiException catch (error) {
+      throw Exception(
+        error.alert?.trim().isNotEmpty == true
+            ? error.alert!
+            : error.message,
+      );
     }
+  }
 
-    return response.data!;
+  Course _toCourse(course_api.CourseSummary course) {
+    return Course(
+      id: course.id,
+      slug: course.slug,
+      fieldTag: course.targetTrack,
+      startDate: course.startDate ?? '',
+      endDate: course.endDate ?? '',
+      metadata: CourseMetadata(
+        title: course.metadata.title,
+        description: course.metadata.description ?? '',
+        phase: course.metadata.phase,
+        attributes: course.metadata.attributes,
+      ),
+      status: course.status,
+      createdAt:
+          course.createdAt ?? DateTime.fromMillisecondsSinceEpoch(0, isUtc: true),
+      updatedAt:
+          course.updatedAt ?? DateTime.fromMillisecondsSinceEpoch(0, isUtc: true),
+      title: course.metadata.title,
+      description: course.metadata.description,
+      phase: course.metadata.phase,
+      targetTrack: course.targetTrack,
+    );
   }
 }

--- a/lib/src/feature/home/domain/usecases/get_courses_usecase.dart
+++ b/lib/src/feature/home/domain/usecases/get_courses_usecase.dart
@@ -1,7 +1,7 @@
 import 'package:a_and_i_report_web_server/src/core/utils/api_error_mapper.dart';
 import 'package:a_and_i_report_web_server/src/feature/auth/domain/repositories/auth_repository.dart';
 import 'package:a_and_i_report_web_server/src/feature/home/data/entities/course.dart';
-import 'package:a_and_i_report_web_server/src/feature/home/data/repositories/course_repository.dart';
+import 'package:aandi_course_api/aandi_course_api.dart' as course_api;
 
 /// 코스 목록 조회 UseCase 인터페이스입니다.
 abstract class GetCoursesUsecase {
@@ -10,13 +10,13 @@ abstract class GetCoursesUsecase {
 
 /// 코스 목록을 조회하는 UseCase 구현체입니다.
 final class GetCoursesUsecaseImpl implements GetCoursesUsecase {
-  final CourseRepository _courseRepository;
+  final course_api.CourseApiClient _courseApiClient;
   final AuthRepository _authRepository;
 
   const GetCoursesUsecaseImpl({
-    required CourseRepository courseRepository,
+    required course_api.CourseApiClient courseApiClient,
     required AuthRepository authRepository,
-  })  : _courseRepository = courseRepository,
+  })  : _courseApiClient = courseApiClient,
         _authRepository = authRepository;
 
   @override
@@ -27,7 +27,6 @@ final class GetCoursesUsecaseImpl implements GetCoursesUsecase {
       throw Exception('인증되지 않은 사용자입니다. 로그인이 필요합니다.');
     }
 
-    final authorization = 'Bearer $token';
     final requests = <({String? status, String? phase, String? track})>[
       (status: null, phase: null, track: null),
       (status: 'PUBLISHED', phase: null, track: null),
@@ -38,26 +37,27 @@ final class GetCoursesUsecaseImpl implements GetCoursesUsecase {
 
     for (final request in requests) {
       try {
-        final response = await _courseRepository.getCourses(
-          authorization,
-          request.status,
-          request.phase,
-          request.track,
+        final courses = await _courseApiClient.getCoursesV2(
+          accessToken: token,
+          status: request.status,
+          phase: request.phase,
+          track: request.track,
         );
 
-        if (!response.success) {
-          throw Exception(
-            ApiErrorMapper.mapApiError(
-              code: response.error?.code,
-              message: response.error?.message,
-              fallbackMessage: '코스 목록 조회에 실패했습니다.',
-            ),
+        if (courses.isNotEmpty) {
+          return _deduplicateCourses(
+            courses.map(_toCourse).toList(growable: false),
           );
         }
-
-        if (response.data.isNotEmpty) {
-          return _deduplicateCourses(response.data);
-        }
+      } on course_api.CourseApiException catch (error) {
+        throw Exception(
+          ApiErrorMapper.mapApiError(
+            code: error.code,
+            message: error.message,
+            alert: error.alert,
+            fallbackMessage: '코스 목록 조회에 실패했습니다.',
+          ),
+        );
       } catch (error) {
         throw Exception(
           ApiErrorMapper.map(
@@ -79,5 +79,30 @@ final class GetCoursesUsecaseImpl implements GetCoursesUsecase {
     }
 
     return uniqueById.values.toList(growable: false);
+  }
+
+  Course _toCourse(course_api.CourseSummary course) {
+    return Course(
+      id: course.id,
+      slug: course.slug,
+      fieldTag: course.targetTrack,
+      startDate: course.startDate ?? '',
+      endDate: course.endDate ?? '',
+      metadata: CourseMetadata(
+        title: course.metadata.title,
+        description: course.metadata.description ?? '',
+        phase: course.metadata.phase,
+        attributes: course.metadata.attributes,
+      ),
+      status: course.status,
+      createdAt:
+          course.createdAt ?? DateTime.fromMillisecondsSinceEpoch(0, isUtc: true),
+      updatedAt:
+          course.updatedAt ?? DateTime.fromMillisecondsSinceEpoch(0, isUtc: true),
+      title: course.metadata.title,
+      description: course.metadata.description,
+      phase: course.metadata.phase,
+      targetTrack: course.targetTrack,
+    );
   }
 }

--- a/lib/src/feature/home/domain/usecases/get_report_summary_usecase.dart
+++ b/lib/src/feature/home/domain/usecases/get_report_summary_usecase.dart
@@ -1,7 +1,8 @@
 import 'package:a_and_i_report_web_server/src/core/utils/api_error_mapper.dart';
 import 'package:a_and_i_report_web_server/src/feature/auth/domain/repositories/auth_repository.dart';
 import 'package:a_and_i_report_web_server/src/feature/home/data/entities/report_summary.dart';
-import 'package:a_and_i_report_web_server/src/feature/home/data/repositories/report_summary_repository.dart';
+import 'package:a_and_i_report_web_server/src/feature/home/data/dtos/report_summary_response_dto.dart';
+import 'package:aandi_course_api/aandi_course_api.dart' as course_api;
 
 /// 과제 목록을 조회하는 UseCase 구현체입니다.
 ///
@@ -12,10 +13,10 @@ import 'package:a_and_i_report_web_server/src/feature/home/data/repositories/rep
 /// 4. [ReportSummaryRepository]를 호출하여 데이터를 받아옵니다.
 final class GetReportSummaryUsecaseImpl implements GetReportSummaryUsecase {
   final AuthRepository authRepository;
-  final ReportSummaryRepository reportSummaryRepository;
+  final course_api.CourseApiClient courseApiClient;
   const GetReportSummaryUsecaseImpl({
     required this.authRepository,
-    required this.reportSummaryRepository,
+    required this.courseApiClient,
   });
 
   @override
@@ -31,22 +32,18 @@ final class GetReportSummaryUsecaseImpl implements GetReportSummaryUsecase {
       throw Exception('인증되지 않은 사용자입니다. 로그인이 필요합니다.');
     }
 
-    final authorization = 'Bearer $token';
     try {
-      final outlineResponse = await reportSummaryRepository.getOutline(
-        authorization,
-        courseSlug,
+      final outline = await courseApiClient.getCourseOutlineV2(
+        accessToken: token,
+        courseSlug: courseSlug,
       );
 
-      if (!outlineResponse.success) {
-        throw Exception(
-          ApiErrorMapper.mapApiError(
-            code: outlineResponse.error?.code,
-            message: outlineResponse.error?.message,
-            fallbackMessage: '코스 목차 조회에 실패했습니다.',
-          ),
-        );
-      }
+      final outlineResponse = CourseOutlineResponseDto.fromJson(<String, dynamic>{
+        'success': true,
+        'data': outline.toJson(),
+        'error': null,
+        'timestamp': null,
+      });
 
       final reports = outlineResponse.toSummaries();
 
@@ -60,6 +57,15 @@ final class GetReportSummaryUsecaseImpl implements GetReportSummaryUsecase {
       });
 
       return reports;
+    } on course_api.CourseApiException catch (error) {
+      throw Exception(
+        ApiErrorMapper.mapApiError(
+          code: error.code,
+          message: error.message,
+          alert: error.alert,
+          fallbackMessage: '코스 목차 조회에 실패했습니다.',
+        ),
+      );
     } catch (error) {
       throw Exception(
         ApiErrorMapper.map(

--- a/lib/src/feature/home/providers/get_course_by_slug_usecase_provider.dart
+++ b/lib/src/feature/home/providers/get_course_by_slug_usecase_provider.dart
@@ -1,6 +1,6 @@
 import 'package:a_and_i_report_web_server/src/feature/auth/providers/auth_repository_provider.dart';
+import 'package:a_and_i_report_web_server/src/core/providers/package_api_client_providers.dart';
 import 'package:a_and_i_report_web_server/src/feature/home/domain/usecases/get_course_by_slug_usecase.dart';
-import 'package:a_and_i_report_web_server/src/feature/home/providers/course_repository_provider.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -9,7 +9,7 @@ part 'get_course_by_slug_usecase_provider.g.dart';
 @riverpod
 GetCourseBySlugUsecase getCourseBySlugUsecase(Ref ref) {
   return GetCourseBySlugUsecaseImpl(
-    courseRepository: ref.read(courseRepositoryProvider),
+    courseApiClient: ref.read(courseApiClientProvider),
     authRepository: ref.read(authRepositoryProvider),
   );
 }

--- a/lib/src/feature/home/providers/get_course_by_slug_usecase_provider.g.dart
+++ b/lib/src/feature/home/providers/get_course_by_slug_usecase_provider.g.dart
@@ -7,7 +7,7 @@ part of 'get_course_by_slug_usecase_provider.dart';
 // **************************************************************************
 
 String _$getCourseBySlugUsecaseHash() =>
-    r'70d9f12e6607b08d1124182ab7edbcd011c1e5e9';
+    r'd03f10377d0d07a8f6cc48055f313a5aaea526c2';
 
 /// See also [getCourseBySlugUsecase].
 @ProviderFor(getCourseBySlugUsecase)

--- a/lib/src/feature/home/providers/get_courses_usecase_provider.dart
+++ b/lib/src/feature/home/providers/get_courses_usecase_provider.dart
@@ -1,6 +1,6 @@
 import 'package:a_and_i_report_web_server/src/feature/auth/providers/auth_repository_provider.dart';
+import 'package:a_and_i_report_web_server/src/core/providers/package_api_client_providers.dart';
 import 'package:a_and_i_report_web_server/src/feature/home/domain/usecases/get_courses_usecase.dart';
-import 'package:a_and_i_report_web_server/src/feature/home/providers/course_repository_provider.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -9,7 +9,7 @@ part 'get_courses_usecase_provider.g.dart';
 @riverpod
 GetCoursesUsecase getCoursesUsecase(Ref ref) {
   return GetCoursesUsecaseImpl(
-    courseRepository: ref.read(courseRepositoryProvider),
+    courseApiClient: ref.read(courseApiClientProvider),
     authRepository: ref.read(authRepositoryProvider),
   );
 }

--- a/lib/src/feature/home/providers/get_courses_usecase_provider.g.dart
+++ b/lib/src/feature/home/providers/get_courses_usecase_provider.g.dart
@@ -6,7 +6,7 @@ part of 'get_courses_usecase_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$getCoursesUsecaseHash() => r'2d4ae3644b295cf18300e9596080e63e7dec1bc4';
+String _$getCoursesUsecaseHash() => r'3e8f7fda73015a29053c2c7307d63b78ed8e6e17';
 
 /// See also [getCoursesUsecase].
 @ProviderFor(getCoursesUsecase)

--- a/lib/src/feature/home/providers/get_report_summary_usecase_provider.dart
+++ b/lib/src/feature/home/providers/get_report_summary_usecase_provider.dart
@@ -1,6 +1,6 @@
 import 'package:a_and_i_report_web_server/src/feature/auth/providers/auth_repository_provider.dart';
+import 'package:a_and_i_report_web_server/src/core/providers/package_api_client_providers.dart';
 import 'package:a_and_i_report_web_server/src/feature/home/domain/usecases/get_report_summary_usecase.dart';
-import 'package:a_and_i_report_web_server/src/feature/home/providers/report_summary_repository_provider.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -9,6 +9,7 @@ part 'get_report_summary_usecase_provider.g.dart';
 @riverpod
 GetReportSummaryUsecase getReportSummaryUsecase(Ref ref) {
   return GetReportSummaryUsecaseImpl(
-      authRepository: ref.read(authRepositoryProvider),
-      reportSummaryRepository: ref.read(reportSummaryRepositoryProvider));
+    authRepository: ref.read(authRepositoryProvider),
+    courseApiClient: ref.read(courseApiClientProvider),
+  );
 }

--- a/lib/src/feature/home/providers/get_report_summary_usecase_provider.g.dart
+++ b/lib/src/feature/home/providers/get_report_summary_usecase_provider.g.dart
@@ -7,7 +7,7 @@ part of 'get_report_summary_usecase_provider.dart';
 // **************************************************************************
 
 String _$getReportSummaryUsecaseHash() =>
-    r'773ceaaa877f7f11fabe6d7d75cd5ad6303905bd';
+    r'b5d6a352854e7a70d423ce9ec0a6a108ae542d29';
 
 /// See also [getReportSummaryUsecase].
 @ProviderFor(getReportSummaryUsecase)

--- a/lib/src/feature/reports/data/datasources/submission_stream_remote_datasource.dart
+++ b/lib/src/feature/reports/data/datasources/submission_stream_remote_datasource.dart
@@ -30,7 +30,9 @@ class SubmissionStreamRemoteDatasource {
                 headers: {
                   'Accept': 'text/event-stream',
                   'Cache-Control': 'no-cache',
-                  'Authorization': 'Bearer $accessToken',
+                  'Authenticate': 'Bearer $accessToken',
+                  'deviceOS': 'web',
+                  'timestamp': DateTime.now().toUtc().toIso8601String(),
                 }.jsify()! as web.HeadersInit,
                 signal: abortController.signal,
                 credentials: 'same-origin',

--- a/lib/src/feature/reports/data/dtos/report_detail_response_dto.dart
+++ b/lib/src/feature/reports/data/dtos/report_detail_response_dto.dart
@@ -1,3 +1,4 @@
+import 'package:a_and_i_report_web_server/src/core/network/base_response.dart';
 import 'package:a_and_i_report_web_server/src/feature/home/data/entities/level.dart';
 import 'package:a_and_i_report_web_server/src/feature/home/data/entities/report_type.dart';
 import 'package:a_and_i_report_web_server/src/feature/reports/data/entities/report.dart';
@@ -26,13 +27,13 @@ class ReportDetailResponseDto {
 
   /// JSON 응답을 DTO로 변환합니다.
   factory ReportDetailResponseDto.fromJson(Map<String, dynamic> json) {
-    final rawData = json['data'];
+    final baseResponse = BaseResponse<Report>.fromJson(json, _parseReport);
 
     return ReportDetailResponseDto(
-      success: json['success'] == true,
-      data: _parseReport(rawData),
-      error: ReportDetailApiErrorDto.fromNullableJson(json['error']),
-      timestamp: json['timestamp']?.toString(),
+      success: baseResponse.success,
+      data: baseResponse.data,
+      error: ReportDetailApiErrorDto.fromBaseError(baseResponse.error),
+      timestamp: baseResponse.timestamp,
     );
   }
 }
@@ -43,6 +44,8 @@ class ReportDetailApiErrorDto {
   const ReportDetailApiErrorDto({
     this.code,
     this.message,
+    this.value,
+    this.alert,
   });
 
   /// 서버 에러 코드입니다.
@@ -51,11 +54,33 @@ class ReportDetailApiErrorDto {
   /// 사용자에게 표시할 수 있는 에러 메시지입니다.
   final String? message;
 
+  /// 서버의 공통 에러 value 입니다.
+  final String? value;
+
+  /// 사용자에게 바로 노출할 alert 문구입니다.
+  final String? alert;
+
   /// JSON 응답을 DTO로 변환합니다.
   factory ReportDetailApiErrorDto.fromJson(Map<String, dynamic> json) {
     return ReportDetailApiErrorDto(
       code: json['code']?.toString(),
       message: json['message']?.toString(),
+      value: json['value']?.toString(),
+      alert: json['alert']?.toString(),
+    );
+  }
+
+  /// 공통 BaseResponse 에러를 DTO로 변환합니다.
+  factory ReportDetailApiErrorDto.fromBaseError(BaseResponseError? error) {
+    if (error == null) {
+      return const ReportDetailApiErrorDto();
+    }
+
+    return ReportDetailApiErrorDto(
+      code: error.code?.toString(),
+      message: error.message,
+      value: error.value,
+      alert: error.alert,
     );
   }
 

--- a/lib/src/feature/reports/data/repositories/submission_repository.dart
+++ b/lib/src/feature/reports/data/repositories/submission_repository.dart
@@ -1,5 +1,3 @@
-import 'package:aandi_api_endpoints/aandi_api_endpoints.dart';
-import 'package:a_and_i_report_web_server/src/feature/reports/data/dtos/submission_response_dto.dart';
 import 'package:dio/dio.dart';
 import 'package:retrofit/retrofit.dart';
 
@@ -12,8 +10,8 @@ abstract class SubmissionRepository {
       _SubmissionRepository;
 
   /// 소스 코드 제출을 생성합니다.
-  @POST(AandiApiEndpointTemplate.submissions)
-  Future<SubmissionResponseDto> createSubmission(
+  @POST('/v1/submissions')
+  Future<dynamic> createSubmission(
     @Header('Authorization') String authorization,
     @Header('Content-Type') String contentType,
     @Header('accept') String accept,
@@ -21,14 +19,14 @@ abstract class SubmissionRepository {
   );
 
   /// 제출 최종 결과를 조회합니다.
-  @GET(AandiApiEndpointTemplate.submissionById)
+  @GET('/v1/submissions/{submissionId}')
   Future<dynamic> getSubmissionResult(
     @Path('submissionId') String submissionId,
     @Header('Authorization') String authorization,
   );
 
   /// 특정 문제에 대한 내 제출 목록을 조회합니다.
-  @GET(AandiApiEndpointTemplate.myProblemSubmissions)
+  @GET('/v1/problems/{problemId}/submissions/me')
   Future<dynamic> getMyProblemSubmissions(
     @Path('problemId') String problemId,
     @Header('Authorization') String authorization,

--- a/lib/src/feature/reports/data/repositories/submission_repository.g.dart
+++ b/lib/src/feature/reports/data/repositories/submission_repository.g.dart
@@ -18,7 +18,7 @@ class _SubmissionRepository implements SubmissionRepository {
   final ParseErrorLogger? errorLogger;
 
   @override
-  Future<SubmissionResponseDto> createSubmission(
+  Future<dynamic> createSubmission(
     String authorization,
     String contentType,
     String accept,
@@ -34,7 +34,7 @@ class _SubmissionRepository implements SubmissionRepository {
     _headers.removeWhere((k, v) => v == null);
     final _data = <String, dynamic>{};
     _data.addAll(request);
-    final _options = _setStreamType<SubmissionResponseDto>(
+    final _options = _setStreamType<dynamic>(
       Options(
         method: 'POST',
         headers: _headers,
@@ -49,14 +49,8 @@ class _SubmissionRepository implements SubmissionRepository {
           )
           .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
     );
-    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
-    late SubmissionResponseDto _value;
-    try {
-      _value = SubmissionResponseDto.fromJson(_result.data!);
-    } on Object catch (e, s) {
-      errorLogger?.logError(e, s, _options);
-      rethrow;
-    }
+    final _result = await _dio.fetch(_options);
+    final _value = _result.data;
     return _value;
   }
 

--- a/lib/src/feature/reports/domain/usecases/create_submission_usecase.dart
+++ b/lib/src/feature/reports/domain/usecases/create_submission_usecase.dart
@@ -35,19 +35,18 @@ final class CreateSubmissionUsecaseImpl implements CreateSubmissionUsecase {
       throw Exception('사용자 publicCode를 확인할 수 없습니다.');
     }
 
-    final request = oj_api.SubmissionCreateRequest(
-      publicCode: publicCode,
-      problemId: problemId,
-      language: language,
-      code: code,
-      options: const oj_api.SubmissionOptions(
-        realtimeFeedback: true,
-      ),
-    );
     try {
-      final response = await ojApiClient.createSubmissionV2(
+      final response = await ojApiClient.createSubmission(
         accessToken: token,
-        request: request,
+        request: <String, dynamic>{
+          'publicCode': publicCode,
+          'problemId': problemId,
+          'language': language,
+          'code': code,
+          'options': const <String, dynamic>{
+            'realtimeFeedback': true,
+          },
+        },
       );
       return SubmissionResponseDto(
         submissionId: response.submissionId,

--- a/lib/src/feature/reports/domain/usecases/create_submission_usecase.dart
+++ b/lib/src/feature/reports/domain/usecases/create_submission_usecase.dart
@@ -1,17 +1,15 @@
-import 'package:a_and_i_report_web_server/src/core/network/base_response.dart';
 import 'package:a_and_i_report_web_server/src/core/utils/api_error_mapper.dart';
 import 'package:a_and_i_report_web_server/src/feature/auth/domain/repositories/auth_repository.dart';
-import 'package:a_and_i_report_web_server/src/feature/reports/data/dtos/submission_request_dto.dart';
 import 'package:a_and_i_report_web_server/src/feature/reports/data/dtos/submission_response_dto.dart';
-import 'package:a_and_i_report_web_server/src/feature/reports/data/repositories/submission_repository.dart';
+import 'package:aandi_oj_api/aandi_oj_api.dart' as oj_api;
 
 /// 제출 생성 UseCase 구현체입니다.
 final class CreateSubmissionUsecaseImpl implements CreateSubmissionUsecase {
-  final SubmissionRepository submissionRepository;
+  final oj_api.OjApiClient ojApiClient;
   final AuthRepository authRepository;
 
   const CreateSubmissionUsecaseImpl({
-    required this.submissionRepository,
+    required this.ojApiClient,
     required this.authRepository,
   });
 
@@ -37,50 +35,34 @@ final class CreateSubmissionUsecaseImpl implements CreateSubmissionUsecase {
       throw Exception('사용자 publicCode를 확인할 수 없습니다.');
     }
 
-    final request = SubmissionRequestDto(
+    final request = oj_api.SubmissionCreateRequest(
       publicCode: publicCode,
       problemId: problemId,
       language: language,
       code: code,
-      options: const SubmissionOptionsDto(
+      options: const oj_api.SubmissionOptions(
         realtimeFeedback: true,
       ),
-    ).toJson();
-
-    final rawResponse = await submissionRepository.createSubmission(
-      'Bearer $token',
-      'application/json',
-      'application/json',
-      request,
     );
-
-    if (rawResponse is! Map<String, dynamic>) {
-      throw Exception('제출 응답 형식이 올바르지 않습니다.');
-    }
-
-    final response = BaseResponse<SubmissionResponseDto>.fromJson(
-      rawResponse,
-      (rawData) {
-        if (rawData is! Map<String, dynamic>) {
-          return null;
-        }
-        return SubmissionResponseDto.fromJson(rawData);
-      },
-    );
-
-    if (!response.success || response.data == null) {
+    try {
+      final response = await ojApiClient.createSubmissionV2(
+        accessToken: token,
+        request: request,
+      );
+      return SubmissionResponseDto(
+        submissionId: response.submissionId,
+        streamUrl: response.streamUrl,
+      );
+    } on oj_api.OjApiException catch (error) {
       throw Exception(
         ApiErrorMapper.mapApiError(
-          code: response.error?.code?.toString(),
-          value: response.error?.value,
-          message: response.error?.message,
-          alert: response.error?.alert,
+          code: error.code,
+          message: error.message,
+          alert: error.alert,
           fallbackMessage: '소스 코드 제출에 실패했습니다.',
         ),
       );
     }
-
-    return response.data!;
   }
 }
 

--- a/lib/src/feature/reports/domain/usecases/create_submission_usecase.dart
+++ b/lib/src/feature/reports/domain/usecases/create_submission_usecase.dart
@@ -1,3 +1,5 @@
+import 'package:a_and_i_report_web_server/src/core/network/base_response.dart';
+import 'package:a_and_i_report_web_server/src/core/utils/api_error_mapper.dart';
 import 'package:a_and_i_report_web_server/src/feature/auth/domain/repositories/auth_repository.dart';
 import 'package:a_and_i_report_web_server/src/feature/reports/data/dtos/submission_request_dto.dart';
 import 'package:a_and_i_report_web_server/src/feature/reports/data/dtos/submission_response_dto.dart';
@@ -45,12 +47,40 @@ final class CreateSubmissionUsecaseImpl implements CreateSubmissionUsecase {
       ),
     ).toJson();
 
-    return await submissionRepository.createSubmission(
+    final rawResponse = await submissionRepository.createSubmission(
       'Bearer $token',
       'application/json',
       'application/json',
       request,
     );
+
+    if (rawResponse is! Map<String, dynamic>) {
+      throw Exception('제출 응답 형식이 올바르지 않습니다.');
+    }
+
+    final response = BaseResponse<SubmissionResponseDto>.fromJson(
+      rawResponse,
+      (rawData) {
+        if (rawData is! Map<String, dynamic>) {
+          return null;
+        }
+        return SubmissionResponseDto.fromJson(rawData);
+      },
+    );
+
+    if (!response.success || response.data == null) {
+      throw Exception(
+        ApiErrorMapper.mapApiError(
+          code: response.error?.code?.toString(),
+          value: response.error?.value,
+          message: response.error?.message,
+          alert: response.error?.alert,
+          fallbackMessage: '소스 코드 제출에 실패했습니다.',
+        ),
+      );
+    }
+
+    return response.data!;
   }
 }
 

--- a/lib/src/feature/reports/domain/usecases/get_my_problem_submissions_usecase.dart
+++ b/lib/src/feature/reports/domain/usecases/get_my_problem_submissions_usecase.dart
@@ -1,18 +1,17 @@
 import 'package:a_and_i_report_web_server/src/core/utils/api_error_mapper.dart';
 import 'package:a_and_i_report_web_server/src/feature/auth/domain/repositories/auth_repository.dart';
-import 'package:a_and_i_report_web_server/src/feature/reports/data/dtos/submission_api_payload_parser.dart';
 import 'package:a_and_i_report_web_server/src/feature/reports/data/entities/submission_result.dart';
-import 'package:a_and_i_report_web_server/src/feature/reports/data/repositories/submission_repository.dart';
+import 'package:aandi_oj_api/aandi_oj_api.dart' as oj_api;
 
 /// 특정 문제에 대한 내 제출 이력을 조회하는 UseCase 구현체입니다.
 final class GetMyProblemSubmissionsUsecaseImpl
     implements GetMyProblemSubmissionsUsecase {
   const GetMyProblemSubmissionsUsecaseImpl({
-    required this.submissionRepository,
+    required this.ojApiClient,
     required this.authRepository,
   });
 
-  final SubmissionRepository submissionRepository;
+  final oj_api.OjApiClient ojApiClient;
   final AuthRepository authRepository;
 
   @override
@@ -23,14 +22,44 @@ final class GetMyProblemSubmissionsUsecaseImpl
     }
 
     try {
-      final response = await submissionRepository.getMyProblemSubmissions(
-        problemId,
-        'Bearer $token',
+      final response = await ojApiClient.getMyProblemSubmissionsV2(
+        accessToken: token,
+        problemId: problemId,
       );
 
-      return SubmissionApiPayloadParser.parseSubmissionList(response)
-          .map((submission) => submission.toEntity())
+      return response
+          .map(
+            (submission) => SubmissionResult(
+              submissionId: submission.submissionId,
+              problemId: submission.problemId,
+              language: submission.language,
+              status: submission.status,
+              testCases: submission.testCases
+                  .map(
+                    (testCase) => SubmissionTestCaseResult(
+                      caseId: testCase.caseId,
+                      status: testCase.status,
+                      timeMs: testCase.timeMs,
+                      memoryMb: testCase.memoryMb,
+                      output: testCase.output,
+                      error: testCase.error,
+                    ),
+                  )
+                  .toList(growable: false),
+              createdAt: submission.createdAt,
+              completedAt: submission.completedAt,
+            ),
+          )
           .toList(growable: false);
+    } on oj_api.OjApiException catch (error) {
+      throw Exception(
+        ApiErrorMapper.mapApiError(
+          code: error.code,
+          message: error.message,
+          alert: error.alert,
+          fallbackMessage: '이전 제출 이력을 불러오지 못했습니다.',
+        ),
+      );
     } catch (error) {
       throw Exception(
         ApiErrorMapper.map(

--- a/lib/src/feature/reports/domain/usecases/get_my_problem_submissions_usecase.dart
+++ b/lib/src/feature/reports/domain/usecases/get_my_problem_submissions_usecase.dart
@@ -1,3 +1,4 @@
+import 'package:a_and_i_report_web_server/src/core/utils/api_error_mapper.dart';
 import 'package:a_and_i_report_web_server/src/feature/auth/domain/repositories/auth_repository.dart';
 import 'package:a_and_i_report_web_server/src/feature/reports/data/dtos/submission_api_payload_parser.dart';
 import 'package:a_and_i_report_web_server/src/feature/reports/data/entities/submission_result.dart';
@@ -17,15 +18,27 @@ final class GetMyProblemSubmissionsUsecaseImpl
   @override
   Future<List<SubmissionResult>> call(String problemId) async {
     final token = await authRepository.getToken();
+    if (token == null || token.isEmpty) {
+      throw Exception('인증되지 않은 사용자입니다. 로그인이 필요합니다.');
+    }
 
-    final response = await submissionRepository.getMyProblemSubmissions(
-      problemId,
-      'Bearer $token',
-    );
+    try {
+      final response = await submissionRepository.getMyProblemSubmissions(
+        problemId,
+        'Bearer $token',
+      );
 
-    return SubmissionApiPayloadParser.parseSubmissionList(response)
-        .map((submission) => submission.toEntity())
-        .toList(growable: false);
+      return SubmissionApiPayloadParser.parseSubmissionList(response)
+          .map((submission) => submission.toEntity())
+          .toList(growable: false);
+    } catch (error) {
+      throw Exception(
+        ApiErrorMapper.map(
+          error,
+          fallbackMessage: '이전 제출 이력을 불러오지 못했습니다.',
+        ),
+      );
+    }
   }
 }
 

--- a/lib/src/feature/reports/domain/usecases/get_my_problem_submissions_usecase.dart
+++ b/lib/src/feature/reports/domain/usecases/get_my_problem_submissions_usecase.dart
@@ -22,7 +22,7 @@ final class GetMyProblemSubmissionsUsecaseImpl
     }
 
     try {
-      final response = await ojApiClient.getMyProblemSubmissionsV2(
+      final response = await ojApiClient.getMyProblemSubmissions(
         accessToken: token,
         problemId: problemId,
       );

--- a/lib/src/feature/reports/domain/usecases/get_report_detail_usecase.dart
+++ b/lib/src/feature/reports/domain/usecases/get_report_detail_usecase.dart
@@ -1,7 +1,8 @@
 import 'package:a_and_i_report_web_server/src/core/utils/api_error_mapper.dart';
 import 'package:a_and_i_report_web_server/src/feature/auth/domain/repositories/auth_repository.dart';
+import 'package:a_and_i_report_web_server/src/feature/reports/data/dtos/report_detail_response_dto.dart';
 import 'package:a_and_i_report_web_server/src/feature/reports/data/entities/report.dart';
-import 'package:a_and_i_report_web_server/src/feature/reports/data/repositories/report_repository.dart';
+import 'package:aandi_course_api/aandi_course_api.dart' as course_api;
 
 /// 과제 상세 정보를 조회하는 UseCase 구현체입니다.
 ///
@@ -9,11 +10,11 @@ import 'package:a_and_i_report_web_server/src/feature/reports/data/repositories/
 /// 1. 인증 토큰 존재 여부를 확인합니다.
 /// 2. [id]에 해당하는 과제 정보를 [ReportRepository]를 통해 요청합니다.
 final class GetReportDetailUsecaseImpl implements GetReportDetailUsecase {
-  final ReportRepository reportRepository;
+  final course_api.CourseApiClient courseApiClient;
   final AuthRepository authRepository;
 
   const GetReportDetailUsecaseImpl({
-    required this.reportRepository,
+    required this.courseApiClient,
     required this.authRepository,
   });
 
@@ -27,25 +28,36 @@ final class GetReportDetailUsecaseImpl implements GetReportDetailUsecase {
       throw Exception('인증되지 않은 사용자입니다. 로그인이 필요합니다.');
     }
 
-    final authorization = 'Bearer $token';
     try {
-      final response = await reportRepository.getReportDetailById(
-        courseSlug,
-        assignmentId,
-        authorization,
+      final assignment = await courseApiClient.getCourseAssignmentV2(
+        accessToken: token,
+        courseSlug: courseSlug,
+        assignmentId: assignmentId,
       );
 
-      if (!response.success || response.data == null) {
+      final response = ReportDetailResponseDto.fromJson(<String, dynamic>{
+        'success': true,
+        'data': assignment.toJson(),
+        'error': null,
+        'timestamp': null,
+      });
+
+      if (response.data == null) {
         throw Exception(
-          ApiErrorMapper.mapApiError(
-            code: response.error?.code,
-            message: response.error?.message,
-            fallbackMessage: '과제 상세 조회에 실패했습니다.',
-          ),
+          '과제 상세 응답을 해석하지 못했습니다.',
         );
       }
 
       return response.data!;
+    } on course_api.CourseApiException catch (error) {
+      throw Exception(
+        ApiErrorMapper.mapApiError(
+          code: error.code,
+          message: error.message,
+          alert: error.alert,
+          fallbackMessage: '과제 상세 조회에 실패했습니다.',
+        ),
+      );
     } catch (error) {
       throw Exception(
         ApiErrorMapper.map(

--- a/lib/src/feature/reports/domain/usecases/get_submission_result_usecase.dart
+++ b/lib/src/feature/reports/domain/usecases/get_submission_result_usecase.dart
@@ -1,3 +1,4 @@
+import 'package:a_and_i_report_web_server/src/core/utils/api_error_mapper.dart';
 import 'package:a_and_i_report_web_server/src/feature/auth/domain/repositories/auth_repository.dart';
 import 'package:a_and_i_report_web_server/src/feature/reports/data/dtos/submission_api_payload_parser.dart';
 import 'package:a_and_i_report_web_server/src/feature/reports/data/entities/submission_result.dart';
@@ -17,13 +18,25 @@ final class GetSubmissionResultUsecaseImpl
   @override
   Future<SubmissionResult?> call(String submissionId) async {
     final token = await authRepository.getToken();
+    if (token == null || token.isEmpty) {
+      throw Exception('인증되지 않은 사용자입니다. 로그인이 필요합니다.');
+    }
 
-    final response = await submissionRepository.getSubmissionResult(
-      submissionId,
-      'Bearer $token',
-    );
-    return SubmissionApiPayloadParser.parseSubmissionResult(response)
-        ?.toEntity();
+    try {
+      final response = await submissionRepository.getSubmissionResult(
+        submissionId,
+        'Bearer $token',
+      );
+      return SubmissionApiPayloadParser.parseSubmissionResult(response)
+          ?.toEntity();
+    } catch (error) {
+      throw Exception(
+        ApiErrorMapper.map(
+          error,
+          fallbackMessage: '제출 결과를 불러오지 못했습니다.',
+        ),
+      );
+    }
   }
 }
 

--- a/lib/src/feature/reports/domain/usecases/get_submission_result_usecase.dart
+++ b/lib/src/feature/reports/domain/usecases/get_submission_result_usecase.dart
@@ -1,17 +1,16 @@
 import 'package:a_and_i_report_web_server/src/core/utils/api_error_mapper.dart';
 import 'package:a_and_i_report_web_server/src/feature/auth/domain/repositories/auth_repository.dart';
-import 'package:a_and_i_report_web_server/src/feature/reports/data/dtos/submission_api_payload_parser.dart';
 import 'package:a_and_i_report_web_server/src/feature/reports/data/entities/submission_result.dart';
-import 'package:a_and_i_report_web_server/src/feature/reports/data/repositories/submission_repository.dart';
+import 'package:aandi_oj_api/aandi_oj_api.dart' as oj_api;
 
 /// 제출 최종 결과 조회 UseCase 구현체입니다.
 final class GetSubmissionResultUsecaseImpl
     implements GetSubmissionResultUsecase {
-  final SubmissionRepository submissionRepository;
+  final oj_api.OjApiClient ojApiClient;
   final AuthRepository authRepository;
 
   const GetSubmissionResultUsecaseImpl({
-    required this.submissionRepository,
+    required this.ojApiClient,
     required this.authRepository,
   });
 
@@ -23,12 +22,39 @@ final class GetSubmissionResultUsecaseImpl
     }
 
     try {
-      final response = await submissionRepository.getSubmissionResult(
-        submissionId,
-        'Bearer $token',
+      final response = await ojApiClient.getSubmissionResultV2(
+        accessToken: token,
+        submissionId: submissionId,
       );
-      return SubmissionApiPayloadParser.parseSubmissionResult(response)
-          ?.toEntity();
+      return SubmissionResult(
+        submissionId: response.submissionId,
+        problemId: response.problemId,
+        language: response.language,
+        status: response.status,
+        testCases: response.testCases
+            .map(
+              (testCase) => SubmissionTestCaseResult(
+                caseId: testCase.caseId,
+                status: testCase.status,
+                timeMs: testCase.timeMs,
+                memoryMb: testCase.memoryMb,
+                output: testCase.output,
+                error: testCase.error,
+              ),
+            )
+            .toList(growable: false),
+        createdAt: response.createdAt,
+        completedAt: response.completedAt,
+      );
+    } on oj_api.OjApiException catch (error) {
+      throw Exception(
+        ApiErrorMapper.mapApiError(
+          code: error.code,
+          message: error.message,
+          alert: error.alert,
+          fallbackMessage: '제출 결과를 불러오지 못했습니다.',
+        ),
+      );
     } catch (error) {
       throw Exception(
         ApiErrorMapper.map(

--- a/lib/src/feature/reports/domain/usecases/get_submission_result_usecase.dart
+++ b/lib/src/feature/reports/domain/usecases/get_submission_result_usecase.dart
@@ -22,7 +22,7 @@ final class GetSubmissionResultUsecaseImpl
     }
 
     try {
-      final response = await ojApiClient.getSubmissionResultV2(
+      final response = await ojApiClient.getSubmissionResult(
         accessToken: token,
         submissionId: submissionId,
       );

--- a/lib/src/feature/reports/providers/create_submission_usecase_provider.dart
+++ b/lib/src/feature/reports/providers/create_submission_usecase_provider.dart
@@ -1,6 +1,6 @@
+import 'package:a_and_i_report_web_server/src/core/providers/package_api_client_providers.dart';
 import 'package:a_and_i_report_web_server/src/feature/auth/providers/auth_repository_provider.dart';
 import 'package:a_and_i_report_web_server/src/feature/reports/domain/usecases/create_submission_usecase.dart';
-import 'package:a_and_i_report_web_server/src/feature/reports/providers/submission_repository_provider.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -10,7 +10,7 @@ part 'create_submission_usecase_provider.g.dart';
 @riverpod
 CreateSubmissionUsecase createSubmissionUsecase(Ref ref) {
   return CreateSubmissionUsecaseImpl(
-    submissionRepository: ref.read(submissionRepositoryProvider),
+    ojApiClient: ref.read(ojApiClientProvider),
     authRepository: ref.read(authRepositoryProvider),
   );
 }

--- a/lib/src/feature/reports/providers/create_submission_usecase_provider.g.dart
+++ b/lib/src/feature/reports/providers/create_submission_usecase_provider.g.dart
@@ -7,7 +7,7 @@ part of 'create_submission_usecase_provider.dart';
 // **************************************************************************
 
 String _$createSubmissionUsecaseHash() =>
-    r'83c0658caa0a905edd73cff2bd2d0887a1276665';
+    r'3b3f708a999f2e22f6c2d5d0ca0863fb37ae7e86';
 
 /// 제출 생성 UseCase Provider입니다.
 ///

--- a/lib/src/feature/reports/providers/get_my_problem_submissions_usecase_provider.dart
+++ b/lib/src/feature/reports/providers/get_my_problem_submissions_usecase_provider.dart
@@ -1,6 +1,6 @@
+import 'package:a_and_i_report_web_server/src/core/providers/package_api_client_providers.dart';
 import 'package:a_and_i_report_web_server/src/feature/auth/providers/auth_repository_provider.dart';
 import 'package:a_and_i_report_web_server/src/feature/reports/domain/usecases/get_my_problem_submissions_usecase.dart';
-import 'package:a_and_i_report_web_server/src/feature/reports/providers/submission_repository_provider.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -10,7 +10,7 @@ part 'get_my_problem_submissions_usecase_provider.g.dart';
 @riverpod
 GetMyProblemSubmissionsUsecase getMyProblemSubmissionsUsecase(Ref ref) {
   return GetMyProblemSubmissionsUsecaseImpl(
-    submissionRepository: ref.read(submissionRepositoryProvider),
+    ojApiClient: ref.read(ojApiClientProvider),
     authRepository: ref.read(authRepositoryProvider),
   );
 }

--- a/lib/src/feature/reports/providers/get_my_problem_submissions_usecase_provider.g.dart
+++ b/lib/src/feature/reports/providers/get_my_problem_submissions_usecase_provider.g.dart
@@ -7,7 +7,7 @@ part of 'get_my_problem_submissions_usecase_provider.dart';
 // **************************************************************************
 
 String _$getMyProblemSubmissionsUsecaseHash() =>
-    r'9536d2856092b893a552e1ba4f791a3c1b766bef';
+    r'cdb57e7813df5243a741858817d8a661177957b7';
 
 /// 특정 문제에 대한 내 제출 이력 조회 UseCase Provider입니다.
 ///

--- a/lib/src/feature/reports/providers/get_report_detail_usecase_provider.dart
+++ b/lib/src/feature/reports/providers/get_report_detail_usecase_provider.dart
@@ -1,6 +1,6 @@
+import 'package:a_and_i_report_web_server/src/core/providers/package_api_client_providers.dart';
 import 'package:a_and_i_report_web_server/src/feature/auth/providers/auth_repository_provider.dart';
 import 'package:a_and_i_report_web_server/src/feature/reports/domain/usecases/get_report_detail_usecase.dart';
-import 'package:a_and_i_report_web_server/src/feature/reports/providers/report_repository_provider.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -9,6 +9,7 @@ part 'get_report_detail_usecase_provider.g.dart';
 @riverpod
 GetReportDetailUsecase getReportDetailUsecase(Ref ref) {
   return GetReportDetailUsecaseImpl(
-      authRepository: ref.read(authRepositoryProvider),
-      reportRepository: ref.read(reportRepositoryProvider));
+    authRepository: ref.read(authRepositoryProvider),
+    courseApiClient: ref.read(courseApiClientProvider),
+  );
 }

--- a/lib/src/feature/reports/providers/get_report_detail_usecase_provider.g.dart
+++ b/lib/src/feature/reports/providers/get_report_detail_usecase_provider.g.dart
@@ -7,7 +7,7 @@ part of 'get_report_detail_usecase_provider.dart';
 // **************************************************************************
 
 String _$getReportDetailUsecaseHash() =>
-    r'ef9a669fb2011dd9e09c1a806a0a15ee4835ddd5';
+    r'49cf21dfe2406995f8036f8fd9b2b2e29967095c';
 
 /// See also [getReportDetailUsecase].
 @ProviderFor(getReportDetailUsecase)

--- a/lib/src/feature/reports/providers/get_submission_result_usecase_provider.dart
+++ b/lib/src/feature/reports/providers/get_submission_result_usecase_provider.dart
@@ -1,6 +1,6 @@
+import 'package:a_and_i_report_web_server/src/core/providers/package_api_client_providers.dart';
 import 'package:a_and_i_report_web_server/src/feature/auth/providers/auth_repository_provider.dart';
 import 'package:a_and_i_report_web_server/src/feature/reports/domain/usecases/get_submission_result_usecase.dart';
-import 'package:a_and_i_report_web_server/src/feature/reports/providers/submission_repository_provider.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -10,7 +10,7 @@ part 'get_submission_result_usecase_provider.g.dart';
 @riverpod
 GetSubmissionResultUsecase getSubmissionResultUsecase(Ref ref) {
   return GetSubmissionResultUsecaseImpl(
-    submissionRepository: ref.read(submissionRepositoryProvider),
+    ojApiClient: ref.read(ojApiClientProvider),
     authRepository: ref.read(authRepositoryProvider),
   );
 }

--- a/lib/src/feature/reports/providers/get_submission_result_usecase_provider.g.dart
+++ b/lib/src/feature/reports/providers/get_submission_result_usecase_provider.g.dart
@@ -7,7 +7,7 @@ part of 'get_submission_result_usecase_provider.dart';
 // **************************************************************************
 
 String _$getSubmissionResultUsecaseHash() =>
-    r'9b40839976cae5d2766782e7d7377948c0684801';
+    r'7f3d26b8ba81f7e8713bc8f49073deeacedfc18d';
 
 /// 제출 결과 조회 UseCase Provider입니다.
 ///

--- a/lib/src/feature/user/data/datasources/user_profile_remote_datasource.dart
+++ b/lib/src/feature/user/data/datasources/user_profile_remote_datasource.dart
@@ -1,6 +1,5 @@
 import 'dart:typed_data';
 
-import 'package:aandi_auth/aandi_auth.dart' as auth_api;
 import 'package:a_and_i_report_web_server/src/core/models/user.dart';
 import 'package:dio/dio.dart';
 
@@ -18,14 +17,13 @@ class ChangePasswordRequestException implements Exception {}
 
 /// 사용자 프로필 원격 데이터소스다.
 class UserProfileRemoteDatasource {
-  UserProfileRemoteDatasource({
-    required auth_api.AuthRepository repository,
-    Dio? uploadDio,
-  })  : _repository = repository,
-        _uploadDio = uploadDio ?? Dio();
+  UserProfileRemoteDatasource(
+    this.dio, {
+    required String baseUrl,
+  }) : _baseUrl = baseUrl;
 
-  final auth_api.AuthRepository _repository;
-  final Dio _uploadDio;
+  final Dio dio;
+  final String _baseUrl;
 
   /// `/v2/me` 내 정보 수정 API를 호출한다.
   Future<User?> updateMyProfile({
@@ -36,54 +34,47 @@ class UserProfileRemoteDatasource {
     String? profileImageMimeType,
   }) async {
     try {
-      final _ = authorization;
-      final trimmedNickname = nickname?.trim();
-      final hasNickname = trimmedNickname != null && trimmedNickname.isNotEmpty;
-      final hasProfileImage =
-          profileImageBytes != null && profileImageBytes.isNotEmpty;
+      final formDataMap = <String, dynamic>{};
 
-      if (!hasNickname && !hasProfileImage) {
-        throw UpdateMyProfileRequestException();
+      final trimmedNickname = nickname?.trim();
+      if (trimmedNickname != null && trimmedNickname.isNotEmpty) {
+        formDataMap['nickname'] = trimmedNickname;
       }
 
-      String? profileImageUrl;
-      if (hasProfileImage) {
-        profileImageUrl = await _uploadProfileImage(
-          profileImageBytes: profileImageBytes,
-          profileImageFileName: profileImageFileName ??
-              _resolveDefaultFileName(profileImageMimeType),
-          profileImageMimeType:
-              _resolveMimeType(profileImageMimeType, profileImageFileName),
+      if (profileImageBytes != null && profileImageBytes.isNotEmpty) {
+        final resolvedFileName = profileImageFileName ??
+            _resolveDefaultFileName(profileImageMimeType);
+        formDataMap['profileImage'] = MultipartFile.fromBytes(
+          profileImageBytes,
+          filename: resolvedFileName,
         );
       }
 
-      final response = await _repository.updateProfileV2(
-        nickname: hasNickname ? trimmedNickname : null,
-        profileImageUrl: profileImageUrl,
+      if (formDataMap.isEmpty) {
+        throw UpdateMyProfileRequestException();
+      }
+
+      final response = await dio.patch(
+        _buildUrl('/v2/me'),
+        data: FormData.fromMap(formDataMap),
+        options: Options(
+          headers: {
+            'Authenticate': authorization,
+          },
+        ),
       );
 
-      return User(
-        id: response.id,
-        role: response.role.toApi(),
-        nickname: _resolveNickname(
-          nickname: response.nickname,
-          username: response.username,
-        ),
-        profileImageUrl: response.profileImageUrl,
-        publicCode: response.publicCode,
-      );
-    } on auth_api.AuthApiException catch (error) {
-      if (_isNetworkLike(error.statusCode)) {
-        throw UpdateMyProfileNetworkException();
-      }
-      throw UpdateMyProfileRequestException();
+      return _parseUser(response);
     } on DioException catch (error) {
-      if (_isDioNetworkError(error)) {
+      final isNetworkError = error.type == DioExceptionType.connectionError ||
+          error.type == DioExceptionType.connectionTimeout ||
+          error.type == DioExceptionType.sendTimeout ||
+          error.type == DioExceptionType.receiveTimeout ||
+          error.type == DioExceptionType.unknown;
+      if (isNetworkError) {
         throw UpdateMyProfileNetworkException();
       }
       throw UpdateMyProfileRequestException();
-    } on UpdateMyProfileRequestException {
-      rethrow;
     } catch (_) {
       throw UpdateMyProfileRequestException();
     }
@@ -96,7 +87,6 @@ class UserProfileRemoteDatasource {
     required String newPassword,
   }) async {
     try {
-      final _ = authorization;
       final trimmedCurrentPassword = currentPassword.trim();
       final trimmedNewPassword = newPassword.trim();
 
@@ -104,16 +94,31 @@ class UserProfileRemoteDatasource {
         throw ChangePasswordRequestException();
       }
 
-      final changed = await _repository.changePasswordV2(
-        currentPassword: trimmedCurrentPassword,
-        newPassword: trimmedNewPassword,
+      final response = await dio.patch(
+        _buildUrl('/v2/me/password'),
+        data: {
+          'currentPassword': trimmedCurrentPassword,
+          'newPassword': trimmedNewPassword,
+        },
+        options: Options(
+          headers: {
+            'Authenticate': authorization,
+          },
+        ),
       );
 
-      if (!changed) {
+      final responseData = response.data;
+      if (responseData is! Map<String, dynamic> ||
+          responseData['success'] != true) {
         throw ChangePasswordRequestException();
       }
-    } on auth_api.AuthApiException catch (error) {
-      if (_isNetworkLike(error.statusCode)) {
+    } on DioException catch (error) {
+      final isNetworkError = error.type == DioExceptionType.connectionError ||
+          error.type == DioExceptionType.connectionTimeout ||
+          error.type == DioExceptionType.sendTimeout ||
+          error.type == DioExceptionType.receiveTimeout ||
+          error.type == DioExceptionType.unknown;
+      if (isNetworkError) {
         throw ChangePasswordNetworkException();
       }
       throw ChangePasswordRequestException();
@@ -122,29 +127,6 @@ class UserProfileRemoteDatasource {
     } catch (_) {
       throw ChangePasswordRequestException();
     }
-  }
-
-  Future<String> _uploadProfileImage({
-    required Uint8List profileImageBytes,
-    required String profileImageFileName,
-    required String profileImageMimeType,
-  }) async {
-    final upload = await _repository.requestProfileImageUploadUrlV2(
-      contentType: profileImageMimeType,
-      fileName: profileImageFileName,
-    );
-
-    await _uploadDio.put<void>(
-      upload.uploadUrl,
-      data: profileImageBytes,
-      options: Options(
-        headers: <String, String>{
-          'Content-Type': profileImageMimeType,
-        },
-      ),
-    );
-
-    return upload.profileImageUrl;
   }
 
   String _resolveDefaultFileName(String? mimeType) {
@@ -160,46 +142,57 @@ class UserProfileRemoteDatasource {
     return 'profile.jpg';
   }
 
-  String _resolveMimeType(String? mimeType, String? fileName) {
-    final trimmedMimeType = mimeType?.trim();
-    if (trimmedMimeType != null && trimmedMimeType.isNotEmpty) {
-      return trimmedMimeType;
+  String _buildUrl(String endpoint) {
+    if (_baseUrl.trim().isEmpty) {
+      return endpoint;
+    }
+    return Uri.parse(_baseUrl).resolve(endpoint).toString();
+  }
+
+  User? _parseUser(Response<dynamic> response) {
+    final responseData = response.data;
+    if (responseData is! Map<String, dynamic>) {
+      throw UpdateMyProfileRequestException();
     }
 
-    final lowerFileName = fileName?.toLowerCase() ?? '';
-    if (lowerFileName.endsWith('.png')) {
-      return 'image/png';
+    final isSuccess = responseData['success'] == true;
+    if (!isSuccess) {
+      throw UpdateMyProfileRequestException();
     }
-    if (lowerFileName.endsWith('.webp')) {
-      return 'image/webp';
+
+    final responseDataField = responseData['data'];
+    if (responseDataField is! Map<String, dynamic>) {
+      return null;
     }
-    return 'image/jpeg';
+
+    final dynamic nestedUser = responseDataField['user'];
+    final userData =
+        nestedUser is Map<String, dynamic> ? nestedUser : responseDataField;
+
+    final id = userData['id']?.toString() ?? userData['userId']?.toString();
+    final role = userData['role']?.toString();
+    final nickname = userData['nickName']?.toString() ??
+        userData['nickname']?.toString() ??
+        userData['nick_name']?.toString() ??
+        userData['displayName']?.toString() ??
+        userData['username']?.toString();
+    if (id == null || role == null || nickname == null || nickname.isEmpty) {
+      return null;
+    }
+
+    final profileImage = userData['profileImageUrl']?.toString() ??
+        userData['profileImagePath']?.toString() ??
+        userData['profileImage']?.toString();
+    final publicCode = userData['publicCode']?.toString() ??
+        userData['public_code']?.toString() ??
+        userData['publiccode']?.toString();
+
+    return User(
+      id: id,
+      role: role,
+      nickname: nickname,
+      profileImageUrl: profileImage,
+      publicCode: publicCode,
+    );
   }
-
-  bool _isNetworkLike(int? statusCode) => statusCode == null;
-
-  bool _isDioNetworkError(DioException error) {
-    return error.type == DioExceptionType.connectionError ||
-        error.type == DioExceptionType.connectionTimeout ||
-        error.type == DioExceptionType.sendTimeout ||
-        error.type == DioExceptionType.receiveTimeout ||
-        error.type == DioExceptionType.unknown;
-  }
-}
-
-String _resolveNickname({
-  required String? nickname,
-  required String username,
-}) {
-  final trimmedNickname = nickname?.trim();
-  if (trimmedNickname != null && trimmedNickname.isNotEmpty) {
-    return trimmedNickname;
-  }
-
-  final trimmedUsername = username.trim();
-  if (trimmedUsername.isNotEmpty) {
-    return trimmedUsername;
-  }
-
-  return '동아리원';
 }

--- a/lib/src/feature/user/providers/user_profile_providers.dart
+++ b/lib/src/feature/user/providers/user_profile_providers.dart
@@ -1,27 +1,19 @@
 import 'package:a_and_i_report_web_server/src/core/constants/api_url.dart';
-import 'package:a_and_i_report_web_server/src/feature/auth/data/datasources/local/auth_token_store_adapter.dart';
+import 'package:a_and_i_report_web_server/src/core/providers/dio_provider.dart';
 import 'package:a_and_i_report_web_server/src/feature/auth/providers/auth_repository_provider.dart';
-import 'package:a_and_i_report_web_server/src/feature/auth/providers/local_auth_datasource_provider.dart';
 import 'package:a_and_i_report_web_server/src/feature/user/data/datasources/user_profile_remote_datasource.dart';
 import 'package:a_and_i_report_web_server/src/feature/user/data/repositories/user_profile_repository_impl.dart';
 import 'package:a_and_i_report_web_server/src/feature/user/domain/repositories/user_profile_repository.dart';
 import 'package:a_and_i_report_web_server/src/feature/user/domain/usecases/change_password_usecase.dart';
 import 'package:a_and_i_report_web_server/src/feature/user/domain/usecases/update_my_profile_usecase.dart';
-import 'package:aandi_auth/aandi_auth.dart' as auth_api;
-import 'package:dio/dio.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 /// 내 정보 수정 원격 데이터소스 Provider다.
 final userProfileRemoteDatasourceProvider =
     Provider<UserProfileRemoteDatasource>(
   (ref) => UserProfileRemoteDatasource(
-    repository: auth_api.AuthRepositoryImpl(
-      apiClient: auth_api.AuthApiClient(baseUrl: baseUrl),
-      tokenStore: AuthTokenStoreAdapter(
-        localAuthDatasource: ref.read(localAuthDatasourceProvider),
-      ),
-    ),
-    uploadDio: Dio(),
+    ref.read(dioProvider),
+    baseUrl: baseUrl,
   ),
 );
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -17,47 +17,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.66"
-  aandi_api_endpoints:
-    dependency: "direct main"
+  aandi_api_protocol:
+    dependency: "direct overridden"
     description:
-      path: "packages/aandi_api_endpoints"
+      path: "../A-AND-I-PROTOCOL-API"
       relative: true
     source: path
-    version: "0.1.0"
-  aandi_api_protocol:
-    dependency: transitive
-    description:
-      path: "."
-      ref: "v0.1.0"
-      resolved-ref: c90000ba1c126e3d7c869c33c78611aac5e51278
-      url: "https://github.com/Team-AnI/A-AND-I-PROTOCOL-API.git"
-    source: git
     version: "0.1.0"
   aandi_auth:
     dependency: "direct main"
     description:
-      path: "packages/auth_api"
+      path: "../A-AND-I-AUTH-API"
       relative: true
     source: path
     version: "0.1.0"
   aandi_course_api:
     dependency: "direct main"
     description:
-      path: "packages/aandi_course_api"
+      path: "../A-AND-I-COURSE-API"
       relative: true
     source: path
     version: "0.1.0"
   aandi_oj_api:
     dependency: "direct main"
     description:
-      path: "packages/aandi_oj_api"
+      path: "../A-AND-I-OJ-API"
       relative: true
     source: path
     version: "0.1.0"
   aandi_tech_blog:
     dependency: "direct main"
     description:
-      path: "packages/blog_api"
+      path: "../A-AND-I-TECH-BLOG-API"
       relative: true
     source: path
     version: "0.1.0"
@@ -77,14 +68,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.13.4"
-  ansi_styles:
-    dependency: transitive
-    description:
-      name: ansi_styles
-      sha256: "9c656cc12b3c27b17dd982b2cc5c0cfdfbdabd7bc8f3ae5e8542d9867b47ce8a"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.3.2+1"
   args:
     dependency: transitive
     description:
@@ -201,15 +184,7 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.4.1"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      sha256: fb0f1107cac15a5ea6ef0a6ef71a807b9e4267c713bb93e00e92d737cc8dbd8a
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
@@ -229,14 +204,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.1.0"
-  cli_launcher:
-    dependency: transitive
-    description:
-      name: cli_launcher
-      sha256: "35cf15a3ffaeb9c11849eaa0afba761bb76dceb42d050532bfd3e1299c9748cd"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.3.3+1"
   cli_util:
     dependency: transitive
     description:
@@ -269,14 +236,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
-  conventional_commit:
-    dependency: transitive
-    description:
-      name: conventional_commit
-      sha256: c40b1b449ce2a63fa2ce852f35e3890b1e182f5951819934c0e4a66254bc0dc3
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.1+1"
   convert:
     dependency: transitive
     description:
@@ -732,14 +691,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.2"
-  intl:
-    dependency: transitive
-    description:
-      name: intl
-      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.19.0"
   io:
     dependency: transitive
     description:
@@ -840,26 +791,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
-  melos:
-    dependency: "direct dev"
-    description:
-      name: melos
-      sha256: "3f3ab3f902843d1e5a1b1a4dd39a4aca8ba1056f2d32fd8995210fa2843f646f"
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.3.2"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
@@ -876,14 +819,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
-  mustache_template:
-    dependency: transitive
-    description:
-      name: mustache_template
-      sha256: "544ff0b837836f5ad6b351e7a676ff7c2cad4fa412c465908aeb9358caddb6fc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.4"
   octo_image:
     dependency: transitive
     description:
@@ -980,22 +915,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.2"
-  process:
-    dependency: transitive
-    description:
-      name: process
-      sha256: c6248e4526673988586e8c00bb22a49210c258dc91df5227d5da9748ecf79744
-      url: "https://pub.dev"
-    source: hosted
-    version: "5.0.5"
-  prompts:
-    dependency: transitive
-    description:
-      name: prompts
-      sha256: "3773b845e85a849f01e793c4fc18a45d52d7783b4cb6c0569fad19f9d0a774a1"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.0"
   protobuf:
     dependency: transitive
     description:
@@ -1012,14 +931,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
-  pub_updater:
-    dependency: transitive
-    description:
-      name: pub_updater
-      sha256: "54e8dc865349059ebe7f163d6acce7c89eb958b8047e6d6e80ce93b13d7c9e60"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.4.0"
   pubspec_parse:
     dependency: transitive
     description:
@@ -1253,10 +1164,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.7"
   timing:
     dependency: transitive
     description:
@@ -1417,14 +1328,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.3"
-  yaml_edit:
-    dependency: transitive
-    description:
-      name: yaml_edit
-      sha256: "07c9e63ba42519745182b88ca12264a7ba2484d8239958778dfe4d44fe760488"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.2.4"
 sdks:
   dart: ">=3.10.4 <4.0.0"
   flutter: ">=3.32.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -17,38 +17,47 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.66"
-  aandi_api_protocol:
-    dependency: "direct overridden"
+  aandi_api_endpoints:
+    dependency: "direct main"
     description:
-      path: "../A-AND-I-PROTOCOL-API"
+      path: "packages/aandi_api_endpoints"
       relative: true
     source: path
+    version: "0.1.0"
+  aandi_api_protocol:
+    dependency: transitive
+    description:
+      path: "."
+      ref: "v0.1.0"
+      resolved-ref: c90000ba1c126e3d7c869c33c78611aac5e51278
+      url: "https://github.com/Team-AnI/A-AND-I-PROTOCOL-API.git"
+    source: git
     version: "0.1.0"
   aandi_auth:
     dependency: "direct main"
     description:
-      path: "../A-AND-I-AUTH-API"
+      path: "packages/auth_api"
       relative: true
     source: path
     version: "0.1.0"
   aandi_course_api:
     dependency: "direct main"
     description:
-      path: "../A-AND-I-COURSE-API"
+      path: "packages/aandi_course_api"
       relative: true
     source: path
     version: "0.1.0"
   aandi_oj_api:
     dependency: "direct main"
     description:
-      path: "../A-AND-I-OJ-API"
+      path: "packages/aandi_oj_api"
       relative: true
     source: path
     version: "0.1.0"
   aandi_tech_blog:
     dependency: "direct main"
     description:
-      path: "../A-AND-I-TECH-BLOG-API"
+      path: "packages/blog_api"
       relative: true
     source: path
     version: "0.1.0"
@@ -68,6 +77,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.13.4"
+  ansi_styles:
+    dependency: transitive
+    description:
+      name: ansi_styles
+      sha256: "9c656cc12b3c27b17dd982b2cc5c0cfdfbdabd7bc8f3ae5e8542d9867b47ce8a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.2+1"
   args:
     dependency: transitive
     description:
@@ -188,6 +205,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  charcode:
+    dependency: transitive
+    description:
+      name: charcode
+      sha256: fb0f1107cac15a5ea6ef0a6ef71a807b9e4267c713bb93e00e92d737cc8dbd8a
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -204,6 +229,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.1.0"
+  cli_launcher:
+    dependency: transitive
+    description:
+      name: cli_launcher
+      sha256: "35cf15a3ffaeb9c11849eaa0afba761bb76dceb42d050532bfd3e1299c9748cd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.3+1"
   cli_util:
     dependency: transitive
     description:
@@ -236,6 +269,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  conventional_commit:
+    dependency: transitive
+    description:
+      name: conventional_commit
+      sha256: c40b1b449ce2a63fa2ce852f35e3890b1e182f5951819934c0e4a66254bc0dc3
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.1+1"
   convert:
     dependency: transitive
     description:
@@ -691,6 +732,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.2"
+  intl:
+    dependency: transitive
+    description:
+      name: intl
+      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.19.0"
   io:
     dependency: transitive
     description:
@@ -803,6 +852,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.11.1"
+  melos:
+    dependency: "direct dev"
+    description:
+      name: melos
+      sha256: "3f3ab3f902843d1e5a1b1a4dd39a4aca8ba1056f2d32fd8995210fa2843f646f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.2"
   meta:
     dependency: transitive
     description:
@@ -819,6 +876,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
+  mustache_template:
+    dependency: transitive
+    description:
+      name: mustache_template
+      sha256: "544ff0b837836f5ad6b351e7a676ff7c2cad4fa412c465908aeb9358caddb6fc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.4"
   octo_image:
     dependency: transitive
     description:
@@ -915,6 +980,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.2"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      sha256: c6248e4526673988586e8c00bb22a49210c258dc91df5227d5da9748ecf79744
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.5"
+  prompts:
+    dependency: transitive
+    description:
+      name: prompts
+      sha256: "3773b845e85a849f01e793c4fc18a45d52d7783b4cb6c0569fad19f9d0a774a1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   protobuf:
     dependency: transitive
     description:
@@ -931,6 +1012,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  pub_updater:
+    dependency: transitive
+    description:
+      name: pub_updater
+      sha256: "54e8dc865349059ebe7f163d6acce7c89eb958b8047e6d6e80ce93b13d7c9e60"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.0"
   pubspec_parse:
     dependency: transitive
     description:
@@ -1328,6 +1417,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.3"
+  yaml_edit:
+    dependency: transitive
+    description:
+      name: yaml_edit
+      sha256: "07c9e63ba42519745182b88ca12264a7ba2484d8239958778dfe4d44fe760488"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.4"
 sdks:
   dart: ">=3.10.4 <4.0.0"
   flutter: ">=3.32.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -68,6 +68,10 @@ dependencies:
   flutter_markdown: ^0.7.7+1
   image_picker: ^1.1.2
   cached_network_image: ^3.4.1
+  aandi_auth:
+    path: ../A-AND-I-AUTH-API
+  aandi_tech_blog:
+    path: ../A-AND-I-TECH-BLOG-API
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -72,6 +72,10 @@ dependencies:
     path: ../A-AND-I-AUTH-API
   aandi_tech_blog:
     path: ../A-AND-I-TECH-BLOG-API
+  aandi_course_api:
+    path: ../A-AND-I-COURSE-API
+  aandi_oj_api:
+    path: ../A-AND-I-OJ-API
 
 dev_dependencies:
   flutter_test:
@@ -87,6 +91,12 @@ dev_dependencies:
   retrofit_generator: ^9.7.0
   analyzer: ^7.6.0
   analyzer_plugin: ^0.13.4
+
+dependency_overrides:
+  aandi_api_protocol:
+    path: ../A-AND-I-PROTOCOL-API
+  aandi_auth:
+    path: ../A-AND-I-AUTH-API
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -68,14 +68,6 @@ dependencies:
   flutter_markdown: ^0.7.7+1
   image_picker: ^1.1.2
   cached_network_image: ^3.4.1
-  aandi_auth:
-    path: ../A-AND-I-AUTH-API
-  aandi_tech_blog:
-    path: ../A-AND-I-TECH-BLOG-API
-  aandi_course_api:
-    path: ../A-AND-I-COURSE-API
-  aandi_oj_api:
-    path: ../A-AND-I-OJ-API
 
 dev_dependencies:
   flutter_test:
@@ -91,12 +83,6 @@ dev_dependencies:
   retrofit_generator: ^9.7.0
   analyzer: ^7.6.0
   analyzer_plugin: ^0.13.4
-
-dependency_overrides:
-  aandi_api_protocol:
-    path: ../A-AND-I-PROTOCOL-API
-  aandi_auth:
-    path: ../A-AND-I-AUTH-API
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/test/src/feature/articles/data/datasources/collaborator_lookup_remote_datasource_test.dart
+++ b/test/src/feature/articles/data/datasources/collaborator_lookup_remote_datasource_test.dart
@@ -4,7 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('CollaboratorLookupRemoteDatasourceImpl', () {
-    test('lookupByCode는 /v1/users/lookup에 code 쿼리와 인증 헤더로 요청한다', () async {
+    test('lookupByCode는 /v2/users/lookup에 code 쿼리와 인증 헤더로 요청한다', () async {
       RequestOptions? capturedOptions;
 
       final dio = Dio()
@@ -39,12 +39,14 @@ void main() {
           await datasource.lookupByCode('Bearer access-token', '#OR009');
 
       expect(capturedOptions, isNotNull);
-      expect(capturedOptions!.path, '/v1/users/lookup');
+      expect(capturedOptions!.path, contains('/v2/users/lookup'));
       expect(capturedOptions!.method, 'GET');
       expect(capturedOptions!.queryParameters, <String, dynamic>{
         'code': '#OR009',
       });
-      expect(capturedOptions!.headers['Authorization'], 'Bearer access-token');
+      expect(capturedOptions!.headers['Authenticate'], 'Bearer access-token');
+      expect(capturedOptions!.headers['deviceOS'], isNotNull);
+      expect(capturedOptions!.headers['timestamp'], isNotNull);
 
       expect(result, isNotNull);
       expect(result!.id, '09856e0d-c5be-43d7-ba45-e957d503aa15');

--- a/test/src/feature/articles/data/repositories/post_repository_impl_test.dart
+++ b/test/src/feature/articles/data/repositories/post_repository_impl_test.dart
@@ -94,7 +94,7 @@ void main() {
       );
 
       expect(datasource.getPostId, 'post-xyz');
-      expect(datasource.getPostType, PostType.blog);
+      expect(datasource.getPostAuthorization, 'Bearer token');
       expect(result.id, 'post-1');
       expect(result.title, 'title');
     });
@@ -226,6 +226,7 @@ class FakeLocalAuthDatasource implements LocalAuthDatasource {
 }
 
 class FakePostRemoteDatasource implements PostRemoteDatasource {
+  String? getPostsAuthorization;
   int? getPostsPage;
   int? getPostsSize;
   String? getPostsStatus;
@@ -233,8 +234,8 @@ class FakePostRemoteDatasource implements PostRemoteDatasource {
   int? getDraftsPage;
   int? getDraftsSize;
   PostType? getDraftsType;
+  String? getPostAuthorization;
   String? getPostId;
-  PostType? getPostType;
   String? patchPostId;
   String? deletePostId;
   String? createAuthorization;
@@ -317,19 +318,21 @@ class FakePostRemoteDatasource implements PostRemoteDatasource {
   }
 
   @override
-  Future<PostResponseDto> getPost(String postId, PostType type) async {
+  Future<PostResponseDto> getPost(String authorization, String postId) async {
+    getPostAuthorization = authorization;
     getPostId = postId;
-    getPostType = type;
     return _samplePost(status: 'Published');
   }
 
   @override
   Future<PostListResponseDto> getPosts(
+    String authorization,
     int page,
     int size,
     PostType? type,
     String? status,
   ) async {
+    getPostsAuthorization = authorization;
     getPostsPage = page;
     getPostsSize = size;
     getPostsType = type;

--- a/test/src/feature/articles/data/repositories/post_repository_impl_test.dart
+++ b/test/src/feature/articles/data/repositories/post_repository_impl_test.dart
@@ -318,7 +318,7 @@ class FakePostRemoteDatasource implements PostRemoteDatasource {
   }
 
   @override
-  Future<PostResponseDto> getPost(String authorization, String postId) async {
+  Future<PostResponseDto> getPost(String? authorization, String postId) async {
     getPostAuthorization = authorization;
     getPostId = postId;
     return _samplePost(status: 'Published');
@@ -326,7 +326,7 @@ class FakePostRemoteDatasource implements PostRemoteDatasource {
 
   @override
   Future<PostListResponseDto> getPosts(
-    String authorization,
+    String? authorization,
     int page,
     int size,
     PostType? type,


### PR DESCRIPTION
## 변경 내용 (What)
- 최신 `main` 기준 multi-package workspace 구조에 맞춰 `WEB-CLIENT`를 재정리했습니다
- 기존 클라이언트 요청 처리에서 v2 규약과 맞지 않던 부분을 수정했습니다
- auth/blog/course/oj package 연결 상태를 최신 workspace 구조 기준으로 다시 맞췄습니다

### 주요 수정 사항
- `report` 브랜치를 최신 `upstream/main` 기준으로 rebase
- package submodule 초기화 및 최신 workspace 구조 기준 의존성 정리
- v2 요청 헤더 처리 수정
  - `timestamp`를 UTC ISO-8601 형식으로 수정
  - 인증 헤더를 `Authenticate` 기준으로 정규화
- auth 관련 요청 경로를 v2 기준으로 정리
  - `/v2/auth/login`
  - `/v2/auth/refresh`
  - `/v2/auth/logout`
  - `/v2/me`
  - `/v2/me/password`
  - `/v2/activate`
- blog 공개 조회가 인증 흐름을 타던 부분 수정
  - 게시글 목록/상세 조회는 로그인 없이 public 흐름으로 조회되도록 정리
- 제출 SSE 스트림 요청도 v2 헤더 규약에 맞게 수정
- 최신 workspace/package 구조에 맞게 auth/user/reports provider 및 usecase 연결부 정리

## 확인 방법 (How to check)
- `git submodule update --init --recursive`
- `flutter analyze`

추가 확인 포인트
- QA에서 로그인 요청이 `/v2/auth/login`으로 나가는지
- `timestamp`가 timezone 포함 UTC ISO-8601 형식으로 전송되는지
- 비로그인 상태에서 blog 목록/상세 조회가 정상 동작하는지
- 제출 SSE 스트림 요청에 `Authenticate`, `timestamp` 헤더가 포함되는지

## 체크리스트
- [x] PR 목적이 하나입니다 (한 PR = 한 목적)
- [x] 변경 범위를 최소화했습니다
- [ ] 문서/가이드가 필요하면 함께 업데이트했습니다
- [ ] (선택) 스크린샷/로그/요청·응답 예시를 첨부했습니다

## 참고 (선택)
- 관련 이슈:
- 기타 공유할 내용:
  - 최신 `main` 반영 전 상태에서 작업 중이어서, 먼저 `upstream/main` 기준으로 rebase 후 정리했습니다
  - 로컬 검증 기준 `flutter analyze` 에러는 없고, package 내부 warning/info만 남아 있습니다
  - 로컬 환경 파일인 `android/local.properties`는 변경사항에 포함하지 않았습니다
