### PR TITLE
fix(reports): align bullet markers with first text line

### DIFF
--- a/lib/src/feature/reports/ui/view/content_list_view.dart
+++ b/lib/src/feature/reports/ui/view/content_list_view.dart
@@ -14,9 +14,14 @@ class ContentListView extends StatelessWidget {
           (index) => Padding(
             padding: const EdgeInsets.symmetric(vertical: 13.0),
             child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 5.5),
+                  padding: const EdgeInsets.only(
+                    left: 5.5,
+                    right: 5.5,
+                    top: 8,
+                  ),
                   child: Container(
                     width: 5,
                     height: 5,

--- a/lib/src/feature/reports/ui/view/problem_bullet_list.dart
+++ b/lib/src/feature/reports/ui/view/problem_bullet_list.dart
@@ -18,12 +18,18 @@ class ProblemBulletList extends StatelessWidget {
             (item) => Padding(
               padding: const EdgeInsets.symmetric(vertical: 6),
               child: Row(
-                crossAxisAlignment: CrossAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Icon(
-                    Icons.fiber_manual_record,
-                    size: 10,
-                    color: isDarkMode ? const Color(0xFFE5E7EB) : const Color(0xFF000000),
+                  Padding(
+                    padding: const EdgeInsets.only(top: 7),
+                    child: Icon(
+                      Icons.fiber_manual_record,
+                      size: 10,
+                      color:
+                          isDarkMode
+                              ? const Color(0xFFE5E7EB)
+                              : const Color(0xFF000000),
+                    ),
                   ),
                   const SizedBox(width: 12),
                   Flexible(


### PR DESCRIPTION
## 변경 내용 (What)
- 과제 상세 페이지의 요구 사항/학습 목표 목록 아이콘 정렬을 수정했습니다
- 텍스트가 2줄 이상으로 내려갈 때 목록 아이콘이 가운데에 보이던 문제를, 첫 줄 기준으로 정렬되도록 변경했습니다

## 확인 방법 (How to check)
- 과제 상세 페이지에서 요구 사항 또는 학습 목표 문장이 2줄 이상이 되도록 확인
- 목록 아이콘이 텍스트 블록 가운데가 아니라 첫 줄 기준으로 보이는지 확인

### 스크린샷
<img width="1200" src="https://github.com/user-attachments/assets/a481e277-5ea6-4b93-813f-120a876df9f6" />


## 체크리스트
- [x] PR 목적이 하나입니다 (한 PR = 한 목적)
- [x] 변경 범위를 최소화했습니다
- [ ] 문서/가이드가 필요하면 함께 업데이트했습니다
- [x] (선택) 스크린샷/로그/요청·응답 예시를 첨부했습니다

## 참고 (선택)
- 관련 이슈:
- 기타 공유할 내용:
  - `problem_bullet_list.dart`
  - `content_list_view.dart`
  두 곳의 목록 아이콘 정렬을 함께 맞췄습니다

